### PR TITLE
#81 - The String.join SDK function takes a Char, not a String as the …

### DIFF
--- a/morphir/sdk/core/src/morphir/sdk/String.scala
+++ b/morphir/sdk/core/src/morphir/sdk/String.scala
@@ -65,8 +65,17 @@ object String {
 
   @inline def trim(text: String): String = text.trim()
 
+  /**
+   * Put many strings together with a given separator.
+   */
   def join(sep: Char)(chunks: List[String]): String =
     chunks.mkString(sep.toString())
+
+  /**
+   * Put many strings together with a given separator.
+   */
+  def join(sep: String)(chunks: List[String]): String =
+    chunks.mkString(sep)
 
   def words(str: String): List[String] = str.split("\\s").toList
 

--- a/morphir/sdk/core/test/src/morphir/sdk/StringSpec.scala
+++ b/morphir/sdk/core/test/src/morphir/sdk/StringSpec.scala
@@ -60,6 +60,13 @@ object StringSpec extends DefaultRunnableSpec {
       appendTests(
         ("butter", "fly", "butterfly")
       ): _*
+    ),
+    suite("String.join specs")(
+      joinTests(
+        ("a", List("H", "w", "ii", "n"), "Hawaiian"),
+        (" ", List("cat", "dog", "cow"), "cat dog cow"),
+        ("/", List("home", "evan", "Desktop"), "home/evan/Desktop")
+      ): _*
     )
   )
 
@@ -184,10 +191,19 @@ object StringSpec extends DefaultRunnableSpec {
       }
     }
 
-  def joinTests(cases: (Char.Char, List[String.String], String.String)*) =
+  def joinWithCharTests(cases: (Char.Char, List[String.String], String.String)*) =
     cases.map { case (sep, chunks, expected) =>
       test(
-        s"Given a List[String]: '$chunks' calling join should return '$expected'"
+        s"Given a List[String]: '$chunks' calling join with a Char separator should return '$expected'"
+      ) {
+        assert(String.join(sep)(chunks))(equalTo(expected))
+      }
+    }
+
+  def joinTests(cases: (String.String, List[String.String], String.String)*): Seq[ZSpec[Any, Nothing]] =
+    cases.map { case (sep, chunks, expected) =>
+      test(
+        s"Given a List[String]: '$chunks' calling join with a String separator should return '$expected'"
       ) {
         assert(String.join(sep)(chunks))(equalTo(expected))
       }


### PR DESCRIPTION
…join character.