### PR TITLE
# This is a combination of 3 commits.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -15,7 +15,7 @@ env:
   JVM_OPTS: -XX:+PrintCommandLineFlags -Xss10M # for Java 8 only (sadly, it is not modern enough for JDK_JAVA_OPTIONS)
   scala_212_version: "2.12.20"
   scala_213_version: "2.13.16"
-  scala_3_version: "3.3.4"
+  scala_3_version: "3.3.5"
   SonatypeUrl: "https://finos.sonatype.app/platform/"
   SonatypeAppId: morphir-jvm
   SonatypeStage: "build"
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ["11", "17"]
-        scala: ["2.12.20", "2.13.16", "3.3.4"]
+        scala: ["2.12.20", "2.13.16", "3.3.5"]
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
@@ -76,7 +76,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ["17"] # Note there is no need ro actually run this for multiple JVM versions for JS
-        scala: ["2.12.20", "2.13.16", "3.3.4"]
+        scala: ["2.12.20", "2.13.16", "3.3.5"]
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
@@ -113,7 +113,7 @@ jobs:
       fail-fast: false
       matrix:
         java: ["11"] # Note there is no need ro actually run this for multiple JVM versions for native
-        scala: ["2.12.20", "2.13.16", "3.3.4"]
+        scala: ["2.12.20", "2.13.16", "3.3.5"]
     steps:
       - name: Checkout current branch
         uses: actions/checkout@v4
@@ -263,9 +263,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            out/morphir/3.3.4/**/jvm/
-          key: ${{ runner.os }}-mill-jvm-11-3.3.4-${{ github.sha }}-${{ hashFiles('out') }}
-          restore-keys: ${{ runner.os }}-mill-jvm-11-3.3.4-${{ github.sha }}-
+            out/morphir/3.3.5/**/jvm/
+          key: ${{ runner.os }}-mill-jvm-11-3.3.5-${{ github.sha }}-${{ hashFiles('out') }}
+          restore-keys: ${{ runner.os }}-mill-jvm-11-3.3.5-${{ github.sha }}-
 
       - name: Restore Scala 2.12 JS Build Output From Cache
         uses: actions/cache/restore@v4
@@ -287,9 +287,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            out/morphir/3.3.4/**/js/
-          key: ${{ runner.os }}-mill-js-11-3.3.4-${{ github.sha }}-${{ hashFiles('out') }}
-          restore-keys: ${{ runner.os }}-mill-js-11-3.3.4-${{ github.sha }}-
+            out/morphir/3.3.5/**/js/
+          key: ${{ runner.os }}-mill-js-11-3.3.5-${{ github.sha }}-${{ hashFiles('out') }}
+          restore-keys: ${{ runner.os }}-mill-js-11-3.3.5-${{ github.sha }}-
 
       - name: Restore Scala 2.12 Native Build Output From Cache
         uses: actions/cache/restore@v4
@@ -311,9 +311,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: |
-            out/morphir/3.3.4/**/native/
-          key: ${{ runner.os }}-mill-native-11-3.3.4-${{ github.sha }}-${{ hashFiles('out') }}
-          restore-keys: ${{ runner.os }}-mill-native-11-3.3.4-${{ github.sha }}-
+            out/morphir/3.3.5/**/native/
+          key: ${{ runner.os }}-mill-native-11-3.3.5-${{ github.sha }}-${{ hashFiles('out') }}
+          restore-keys: ${{ runner.os }}-mill-native-11-3.3.5-${{ github.sha }}-
 
       - name: Publish artifacts to Sonatype
         run: ./mill -i -j 0 mill.scalalib.PublishModule/

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: release-drafter/release-drafter@v6
         env:

--- a/mill-build/src/millbuild/deps.scala
+++ b/mill-build/src/millbuild/deps.scala
@@ -273,7 +273,7 @@ object ScalaVersions {
   val all      = if (devMode) Seq(scala3x) else Seq(scala213, scala3x)
   def scala212 = "2.12.20"
   def scala213 = "2.13.16"
-  def scala3x  = "3.3.4"
+  def scala3x  = "3.3.5"
 
   def scalaJSVersion     = "1.17.0"
   def scalaNativeVersion = "0.5.7"

--- a/mill-build/src/millbuild/settings/ScalaNativeBuildSettings.scala
+++ b/mill-build/src/millbuild/settings/ScalaNativeBuildSettings.scala
@@ -12,7 +12,7 @@ object ScalaNativeBuildSettings {
   val config: Config[ScalaNativeBuildSettings] = deriveConfig[ScalaNativeBuildSettings]
   lazy val default: ScalaNativeBuildSettings   = ScalaNativeBuildSettings()
 
-  lazy val defaultVersion = "0.5.5"
+  lazy val defaultVersion = "0.5.7"
 
   implicit lazy val rw: upickle.default.ReadWriter[ScalaNativeBuildSettings] = upickle.default.macroRW
 }

--- a/mill-build/src/millbuild/settings/ScalaSettings.scala
+++ b/mill-build/src/millbuild/settings/ScalaSettings.scala
@@ -22,7 +22,7 @@ object ScalaSettings {
 
   val defaultScala212Version = "2.12.20"
   val defaultScala213Version = "2.13.16"
-  val defaultScala3xVersion  = "3.3.4"
+  val defaultScala3xVersion  = "3.3.5"
   val defaultCrossScalaVersions: List[String] =
     if (devMode) List(defaultScala3xVersion)
     else List(defaultScala3xVersion, defaultScala213Version, defaultScala212Version)

--- a/morphir/ir/src/morphir/ir/Distribution.scala
+++ b/morphir/ir/src/morphir/ir/Distribution.scala
@@ -2,120 +2,141 @@ package morphir.ir
 
 /** Generated based on IR.Distribution
 */
-object Distribution{
+object Distribution {
+
+  final case class Component(
+                              name: morphir.ir.Path.Path,
+                              libraries: morphir.sdk.Dict.Dict[morphir.ir.Package.PackageName, morphir.ir.Package.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]],
+                              inputs: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Type.Type[scala.Unit]],
+                              states: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Type.Type[scala.Unit]],
+                              outputs: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Value[scala.Unit, morphir.ir.Type.Type[scala.Unit]]]
+                            ) {}
 
   sealed trait Distribution {
-  
-    
-  
+
+
   }
-  
-  object Distribution{
-  
+
+  object Distribution {
+
     final case class Library(
-      arg1: morphir.ir.Package.PackageName,
-      arg2: morphir.sdk.Dict.Dict[morphir.ir.Package.PackageName, morphir.ir.Package.Specification[scala.Unit]],
-      arg3: morphir.ir.Package.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]
-    ) extends morphir.ir.Distribution.Distribution{}
-  
+                              packageName: morphir.ir.Package.PackageName,
+                              dependencies: morphir.sdk.Dict.Dict[morphir.ir.Package.PackageName, morphir.ir.Package.Specification[scala.Unit]],
+                              packageDef: morphir.ir.Package.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]
+                            ) extends morphir.ir.Distribution.Distribution {}
+
   }
-  
-  val Library: morphir.ir.Distribution.Distribution.Library.type  = morphir.ir.Distribution.Distribution.Library
-  
+
+  val Library: morphir.ir.Distribution.Distribution.Library.type = morphir.ir.Distribution.Distribution.Library
+
   def insertDependency(
-    dependencyPackageName: morphir.ir.Package.PackageName
-  )(
-    dependencyPackageSpec: morphir.ir.Package.Specification[scala.Unit]
-  )(
-    distribution: morphir.ir.Distribution.Distribution
-  ): morphir.ir.Distribution.Distribution =
+                        dependencyPackageName: morphir.ir.Package.PackageName
+                      )(
+                        dependencyPackageSpec: morphir.ir.Package.Specification[scala.Unit]
+                      )(
+                        distribution: morphir.ir.Distribution.Distribution
+                      ): morphir.ir.Distribution.Distribution =
     distribution match {
-      case morphir.ir.Distribution.Library(packageName, dependencies, packageDef) => 
+      case morphir.ir.Distribution.Library(packageName, dependencies, packageDef) =>
         (morphir.ir.Distribution.Library(
           packageName,
           morphir.sdk.Dict.insert(dependencyPackageName)(dependencyPackageSpec)(dependencies),
           packageDef
-        ) : morphir.ir.Distribution.Distribution)
+        ): morphir.ir.Distribution.Distribution)
     }
-  
+
+  def library(
+               packageName: morphir.ir.Package.PackageName
+             )(
+               dependencies: morphir.sdk.Dict.Dict[morphir.ir.Package.PackageName, morphir.ir.Package.Specification[scala.Unit]]
+             )(
+               packageDef: morphir.ir.Package.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]
+             ): morphir.ir.Distribution.Distribution =
+    (morphir.ir.Distribution.Library(
+      packageName,
+      dependencies,
+      packageDef
+    ): morphir.ir.Distribution.Distribution)
+
+
   def lookupBaseTypeName: morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[morphir.ir.FQName.FQName] =
     ({
-      case fQName @ (packageName, moduleName, localName) => 
+      case fQName @ (packageName, moduleName, localName) =>
         ((distribution: morphir.ir.Distribution.Distribution) =>
           morphir.sdk.Maybe.andThen(((typeSpec: morphir.ir.Type.Specification[scala.Unit]) =>
             typeSpec match {
-              case morphir.ir.Type.TypeAliasSpecification(_, morphir.ir.Type.Reference(_, aliasFQName, _)) => 
+              case morphir.ir.Type.TypeAliasSpecification(_, morphir.ir.Type.Reference(_, aliasFQName, _)) =>
                 morphir.ir.Distribution.lookupBaseTypeName(aliasFQName)(distribution)
-              case _ => 
+              case _ =>
                 (morphir.sdk.Maybe.Just(fQName) : morphir.sdk.Maybe.Maybe[(morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name)])
             }))(morphir.sdk.Maybe.andThen[Module.Specification[Unit], Type.Specification[Unit]](morphir.ir.Module.lookupTypeSpecification(localName))(morphir.ir.Distribution.lookupModuleSpecification(packageName)(moduleName)(distribution))))
     } : morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[morphir.ir.FQName.FQName])
-  
+
   def lookupModuleSpecification(
-    packageName: morphir.ir.Package.PackageName
-  )(
-    modulePath: morphir.ir.Module.ModuleName
-  )(
-    distribution: morphir.ir.Distribution.Distribution
-  ): morphir.sdk.Maybe.Maybe[morphir.ir.Module.Specification[scala.Unit]] =
+                                 packageName: morphir.ir.Package.PackageName
+                               )(
+                                 modulePath: morphir.ir.Module.ModuleName
+                               )(
+                                 distribution: morphir.ir.Distribution.Distribution
+                               ): morphir.sdk.Maybe.Maybe[morphir.ir.Module.Specification[scala.Unit]] =
     distribution match {
-      case morphir.ir.Distribution.Library(libraryPackageName, dependencies, packageDef) => 
+      case morphir.ir.Distribution.Library(libraryPackageName, dependencies, packageDef) =>
         if (morphir.sdk.Basics.equal(packageName)(libraryPackageName)) {
           morphir.ir.Package.lookupModuleSpecification(modulePath)(morphir.ir.Package.definitionToSpecificationWithPrivate(packageDef))
         } else {
           morphir.sdk.Maybe.andThen[Package.Specification[Unit], Module.Specification[Unit]](morphir.ir.Package.lookupModuleSpecification(modulePath))(morphir.sdk.Dict.get(packageName)(dependencies))
         }
     }
-  
+
   def lookupPackageName(
-    distribution: morphir.ir.Distribution.Distribution
-  ): morphir.ir.Package.PackageName =
+                         distribution: morphir.ir.Distribution.Distribution
+                       ): morphir.ir.Package.PackageName =
     distribution match {
-      case morphir.ir.Distribution.Library(packageName, _, _) => 
+      case morphir.ir.Distribution.Library(packageName, _, _) =>
         packageName
     }
-  
+
   def lookupPackageSpecification(
-    distribution: morphir.ir.Distribution.Distribution
-  ): morphir.ir.Package.Specification[scala.Unit] =
+                                  distribution: morphir.ir.Distribution.Distribution
+                                ): morphir.ir.Package.Specification[scala.Unit] =
     distribution match {
-      case morphir.ir.Distribution.Library(_, _, packageDef) => 
+      case morphir.ir.Distribution.Library(_, _, packageDef) =>
         morphir.ir.Package.mapSpecificationAttributes(({
-          case _ => 
-            {}
+          case _ =>
+          {}
         } : scala.Unit => scala.Unit))(morphir.ir.Package.definitionToSpecificationWithPrivate(packageDef))
     }
-  
+
   def lookupTypeConstructor: morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[(morphir.ir.FQName.FQName, morphir.sdk.List.List[morphir.ir.Name.Name], morphir.sdk.List.List[(morphir.ir.Name.Name, morphir.ir.Type.Type[scala.Unit])])] =
     ({
-      case (packageName, moduleName, ctorName) => 
+      case (packageName, moduleName, ctorName) =>
         ((distro: morphir.ir.Distribution.Distribution) =>
           morphir.sdk.Maybe.andThen(((moduleSpec: morphir.ir.Module.Specification[scala.Unit]) =>
             morphir.sdk.List.head(morphir.sdk.List.filterMap(({
-              case (typeName, documentedTypeSpec) => 
+              case (typeName, documentedTypeSpec) =>
                 documentedTypeSpec.value match {
-                  case morphir.ir.Type.CustomTypeSpecification(typeArgs, constructors) => 
+                  case morphir.ir.Type.CustomTypeSpecification(typeArgs, constructors) =>
                     morphir.sdk.Maybe.map(((constructorArgs: morphir.ir.Type.ConstructorArgs[scala.Unit]) =>
                       ((packageName, moduleName, typeName), typeArgs, constructorArgs)))(morphir.sdk.Dict.get(ctorName)(constructors))
-                  case _ => 
+                  case _ =>
                     (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name), morphir.sdk.List.List[morphir.ir.Name.Name], morphir.ir.Type.ConstructorArgs[scala.Unit])])
                 }
             } : ((morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Type.Specification[scala.Unit]])) => morphir.sdk.Maybe.Maybe[((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name), morphir.sdk.List.List[morphir.ir.Name.Name], morphir.ir.Type.ConstructorArgs[scala.Unit])]))(morphir.sdk.Dict.toList(moduleSpec.types)))))(morphir.ir.Distribution.lookupModuleSpecification(packageName)(moduleName)(distro)))
     } : morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[(morphir.ir.FQName.FQName, morphir.sdk.List.List[morphir.ir.Name.Name], morphir.sdk.List.List[(morphir.ir.Name.Name, morphir.ir.Type.Type[scala.Unit])])])
-  
+
   def lookupTypeSpecification: morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[morphir.ir.Type.Specification[scala.Unit]] =
     ({
-      case (packageName, moduleName, localName) => 
+      case (packageName, moduleName, localName) =>
         ((distribution: morphir.ir.Distribution.Distribution) =>
           morphir.sdk.Maybe.andThen[Module.Specification[Unit], Type.Specification[Unit]](morphir.ir.Module.lookupTypeSpecification(localName))(morphir.ir.Distribution.lookupModuleSpecification(packageName)(moduleName)(distribution)))
     } : morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[morphir.ir.Type.Specification[scala.Unit]])
-  
+
   def lookupValueDefinition: morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[morphir.ir.Value.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]] =
     ({
-      case (packageName, moduleName, localName) => 
-        ((distribution: morphir.ir.Distribution.Distribution) =>
-          distribution match {
-            case morphir.ir.Distribution.Library(pName, _, packageDef) => 
+      case (packageName, moduleName, localName) =>
+            ((distribution: morphir.ir.Distribution.Distribution) =>
+              distribution match {
+            case morphir.ir.Distribution.Library(pName, _, packageDef) =>
               if (morphir.sdk.Basics.equal(pName)(packageName)) {
                 morphir.sdk.Maybe.andThen[Module.Definition[Unit, Type.Type[Unit]], Value.Definition[Unit, Type.Type[Unit]]](morphir.ir.Module.lookupValueDefinition(localName))(morphir.ir.Package.lookupModuleDefinition(moduleName)(packageDef))
               } else {
@@ -123,132 +144,132 @@ object Distribution{
               }
           })
     } : morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[morphir.ir.Value.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]])
-  
+
   def lookupValueSpecification: morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[morphir.ir.Value.Specification[scala.Unit]] =
     ({
-      case (packageName, moduleName, localName) => 
+      case (packageName, moduleName, localName) =>
         ((distribution: morphir.ir.Distribution.Distribution) =>
           morphir.sdk.Maybe.andThen[Module.Specification[Unit], Value.Specification[Unit]](morphir.ir.Module.lookupValueSpecification(localName))(morphir.ir.Distribution.lookupModuleSpecification(packageName)(moduleName)(distribution)))
     } : morphir.ir.FQName.FQName => morphir.ir.Distribution.Distribution => morphir.sdk.Maybe.Maybe[morphir.ir.Value.Specification[scala.Unit]])
-  
+
   def resolveAliases(
-    fQName: morphir.ir.FQName.FQName
-  )(
-    distro: morphir.ir.Distribution.Distribution
-  ): morphir.ir.FQName.FQName =
+                      fQName: morphir.ir.FQName.FQName
+                    )(
+                      distro: morphir.ir.Distribution.Distribution
+                    ): morphir.ir.FQName.FQName =
     morphir.sdk.Maybe.withDefault(fQName)(morphir.sdk.Maybe.map(((typeSpec: morphir.ir.Type.Specification[scala.Unit]) =>
       typeSpec match {
-        case morphir.ir.Type.TypeAliasSpecification(_, morphir.ir.Type.Reference(_, aliasFQName, _)) => 
+        case morphir.ir.Type.TypeAliasSpecification(_, morphir.ir.Type.Reference(_, aliasFQName, _)) =>
           aliasFQName
-        case _ => 
+        case _ =>
           fQName
       }))(morphir.ir.Distribution.lookupTypeSpecification(fQName)(distro)))
-  
+
   def resolveRecordConstructors[Ta, Va](
-    value: morphir.ir.Value.Value[Ta, Va]
-  )(
-    distro: morphir.ir.Distribution.Distribution
-  ): morphir.ir.Value.Value[Ta, Va] =
+                                         value: morphir.ir.Value.Value[Ta, Va]
+                                       )(
+                                         distro: morphir.ir.Distribution.Distribution
+                                       ): morphir.ir.Value.Value[Ta, Va] =
     morphir.ir.Value.rewriteValue(((v: morphir.ir.Value.Value[Ta, Va]) =>
       v match {
-        case morphir.ir.Value.Apply(_, fun, lastArg) => 
-          {
-            val (bottomFun, args) = morphir.ir.Value.uncurryApply(fun)(lastArg)
-            
-            bottomFun match {
-              case morphir.ir.Value.Constructor(va, fqn) => 
-                morphir.sdk.Maybe.andThen(((typeSpec: morphir.ir.Type.Specification[scala.Unit]) =>
-                  typeSpec match {
-                    case morphir.ir.Type.TypeAliasSpecification(_, morphir.ir.Type.Record(_, fields)) => 
-                      (morphir.sdk.Maybe.Just((morphir.ir.Value.Record(
-                        va,
-                        morphir.sdk.Dict.fromList(morphir.sdk.List.map2[Name.Name, Value.Value[Ta, Va], (Name.Name, Value.Value[Ta, Va])](morphir.sdk.Tuple.pair)(morphir.sdk.List.map(((x: morphir.ir.Type.Field[scala.Unit]) =>
-                          x.name))(fields))(args))
-                      ) : morphir.ir.Value.Value[Ta, Va])) : morphir.sdk.Maybe.Maybe[morphir.ir.Value.Value[Ta, Va]])
-                    case _ => 
-                      (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[morphir.ir.Value.Value[Ta, Va]])
-                  }))(morphir.ir.Distribution.lookupTypeSpecification(fqn)(distro))
-              case _ => 
-                (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[morphir.ir.Value.Value[Ta, Va]])
-            }
+        case morphir.ir.Value.Apply(_, fun, lastArg) =>
+        {
+          val (bottomFun, args) = morphir.ir.Value.uncurryApply(fun)(lastArg)
+
+          bottomFun match {
+            case morphir.ir.Value.Constructor(va, fqn) =>
+              morphir.sdk.Maybe.andThen(((typeSpec: morphir.ir.Type.Specification[scala.Unit]) =>
+                typeSpec match {
+                  case morphir.ir.Type.TypeAliasSpecification(_, morphir.ir.Type.Record(_, fields)) =>
+                    (morphir.sdk.Maybe.Just((morphir.ir.Value.Record(
+                      va,
+                      morphir.sdk.Dict.fromList(morphir.sdk.List.map2[Name.Name, Value.Value[Ta, Va], (Name.Name, Value.Value[Ta, Va])](morphir.sdk.Tuple.pair)(morphir.sdk.List.map(((x: morphir.ir.Type.Field[scala.Unit]) =>
+                        x.name))(fields))(args))
+                    ) : morphir.ir.Value.Value[Ta, Va])) : morphir.sdk.Maybe.Maybe[morphir.ir.Value.Value[Ta, Va]])
+                  case _ =>
+                    (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[morphir.ir.Value.Value[Ta, Va]])
+                }))(morphir.ir.Distribution.lookupTypeSpecification(fqn)(distro))
+            case _ =>
+              (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[morphir.ir.Value.Value[Ta, Va]])
           }
-        case _ => 
+        }
+        case _ =>
           (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[morphir.ir.Value.Value[Ta, Va]])
       }))(value)
-  
+
   def resolveType(
-    tpe: morphir.ir.Type.Type[scala.Unit]
-  )(
-    distro: morphir.ir.Distribution.Distribution
-  ): morphir.ir.Type.Type[scala.Unit] =
+                   tpe: morphir.ir.Type.Type[scala.Unit]
+                 )(
+                   distro: morphir.ir.Distribution.Distribution
+                 ): morphir.ir.Type.Type[scala.Unit] =
     tpe match {
-      case morphir.ir.Type.Variable(a, name) => 
+      case morphir.ir.Type.Variable(a, name) =>
         (morphir.ir.Type.Variable(
           a,
           name
         ) : morphir.ir.Type.Type[scala.Unit])
-      case morphir.ir.Type.Reference(_, fQName, typeParams) => 
+      case morphir.ir.Type.Reference(_, fQName, typeParams) =>
         morphir.sdk.Maybe.withDefault(tpe)(morphir.sdk.Maybe.map(((typeSpec: morphir.ir.Type.Specification[scala.Unit]) =>
           typeSpec match {
-            case morphir.ir.Type.TypeAliasSpecification(typeParamNames, targetType) => 
+            case morphir.ir.Type.TypeAliasSpecification(typeParamNames, targetType) =>
               morphir.ir.Type.substituteTypeVariables(morphir.sdk.Dict.fromList(morphir.sdk.List.map2[Name.Name, Type.Type[Unit], (Name.Name, Type.Type[Unit])](morphir.sdk.Tuple.pair)(typeParamNames)(typeParams)))(targetType)
-            case _ => 
+            case _ =>
               tpe
           }))(morphir.ir.Distribution.lookupTypeSpecification(fQName)(distro)))
-      case morphir.ir.Type.Tuple(a, elemTypes) => 
+      case morphir.ir.Type.Tuple(a, elemTypes) =>
         (morphir.ir.Type.Tuple(
           a,
           morphir.sdk.List.map(((t: morphir.ir.Type.Type[scala.Unit]) =>
             morphir.ir.Distribution.resolveType(t)(distro)))(elemTypes)
         ) : morphir.ir.Type.Type[scala.Unit])
-      case morphir.ir.Type.Record(a, fields) => 
+      case morphir.ir.Type.Record(a, fields) =>
         (morphir.ir.Type.Record(
           a,
           morphir.sdk.List.map(((f: morphir.ir.Type.Field[scala.Unit]) =>
             f.copy(tpe = morphir.ir.Distribution.resolveType(f.tpe)(distro))))(fields)
         ) : morphir.ir.Type.Type[scala.Unit])
-      case morphir.ir.Type.ExtensibleRecord(a, varName, fields) => 
+      case morphir.ir.Type.ExtensibleRecord(a, varName, fields) =>
         (morphir.ir.Type.ExtensibleRecord(
           a,
           varName,
           morphir.sdk.List.map(((f: morphir.ir.Type.Field[scala.Unit]) =>
             f.copy(tpe = morphir.ir.Distribution.resolveType(f.tpe)(distro))))(fields)
         ) : morphir.ir.Type.Type[scala.Unit])
-      case morphir.ir.Type.Function(a, argType, returnType) => 
+      case morphir.ir.Type.Function(a, argType, returnType) =>
         (morphir.ir.Type.Function(
           a,
           morphir.ir.Distribution.resolveType(argType)(distro),
           morphir.ir.Distribution.resolveType(returnType)(distro)
         ) : morphir.ir.Type.Type[scala.Unit])
-      case morphir.ir.Type.Unit(a) => 
+      case morphir.ir.Type.Unit(a) =>
         (morphir.ir.Type.Unit(a) : morphir.ir.Type.Type[scala.Unit])
     }
-  
+
   def typeSpecifications: morphir.ir.Distribution.Distribution => morphir.sdk.Dict.Dict[morphir.ir.FQName.FQName, morphir.ir.Type.Specification[scala.Unit]] =
     ({
-      case morphir.ir.Distribution.Library(packageName, dependencies, packageDef) => 
-        {
-          val typeSpecsInDependencies: morphir.sdk.Dict.Dict[morphir.ir.FQName.FQName, morphir.ir.Type.Specification[scala.Unit]] = morphir.sdk.Dict.fromList(morphir.sdk.List.concatMap(({
-            case (pName, pSpec) => 
-              morphir.sdk.List.concatMap(({
-                case (mName, mSpec) => 
-                  morphir.sdk.List.map(({
-                    case (tName, documentedTypeSpec) => 
-                      ((pName, mName, tName), documentedTypeSpec.value)
-                  } : ((morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Type.Specification[scala.Unit]])) => ((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])))(morphir.sdk.Dict.toList(mSpec.types))
-              } : ((morphir.ir.Path.Path, morphir.ir.Module.Specification[scala.Unit])) => morphir.sdk.List.List[((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])]))(morphir.sdk.Dict.toList(pSpec.modules))
-          } : ((morphir.ir.Path.Path, morphir.ir.Package.Specification[scala.Unit])) => morphir.sdk.List.List[((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])]))(morphir.sdk.Dict.toList(dependencies)))
-          
-          val typeSpecsInPackage: morphir.sdk.Dict.Dict[morphir.ir.FQName.FQName, morphir.ir.Type.Specification[scala.Unit]] = morphir.sdk.Dict.fromList(morphir.sdk.List.concatMap(({
-            case (mName, accessControlledModuleDef) => 
-              morphir.sdk.List.map(({
-                case (tName, accessControlledDocumentedTypeDef) => 
-                  ((packageName, mName, tName), morphir.ir.Type.definitionToSpecification(accessControlledDocumentedTypeDef.value.value))
-              } : ((morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[scala.Unit]]])) => ((morphir.ir.Path.Path, morphir.ir.Module.ModuleName, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])))(morphir.sdk.Dict.toList(accessControlledModuleDef.value.types))
-          } : ((morphir.ir.Module.ModuleName, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]])) => morphir.sdk.List.List[((morphir.ir.Path.Path, morphir.ir.Module.ModuleName, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])]))(morphir.sdk.Dict.toList(packageDef.modules)))
-          
-          morphir.sdk.Dict.union(typeSpecsInDependencies)(typeSpecsInPackage)
-        }
+      case morphir.ir.Distribution.Library(packageName, dependencies, packageDef) =>
+      {
+        val typeSpecsInDependencies: morphir.sdk.Dict.Dict[morphir.ir.FQName.FQName, morphir.ir.Type.Specification[scala.Unit]] = morphir.sdk.Dict.fromList(morphir.sdk.List.concatMap(({
+          case (pName, pSpec) =>
+            morphir.sdk.List.concatMap(({
+              case (mName, mSpec) =>
+                morphir.sdk.List.map(({
+                  case (tName, documentedTypeSpec) =>
+                    ((pName, mName, tName), documentedTypeSpec.value)
+                } : ((morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Type.Specification[scala.Unit]])) => ((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])))(morphir.sdk.Dict.toList(mSpec.types))
+            } : ((morphir.ir.Path.Path, morphir.ir.Module.Specification[scala.Unit])) => morphir.sdk.List.List[((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])]))(morphir.sdk.Dict.toList(pSpec.modules))
+        } : ((morphir.ir.Path.Path, morphir.ir.Package.Specification[scala.Unit])) => morphir.sdk.List.List[((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])]))(morphir.sdk.Dict.toList(dependencies)))
+
+        val typeSpecsInPackage: morphir.sdk.Dict.Dict[morphir.ir.FQName.FQName, morphir.ir.Type.Specification[scala.Unit]] = morphir.sdk.Dict.fromList(morphir.sdk.List.concatMap(({
+          case (mName, accessControlledModuleDef) =>
+            morphir.sdk.List.map(({
+              case (tName, accessControlledDocumentedTypeDef) =>
+                ((packageName, mName, tName), morphir.ir.Type.definitionToSpecification(accessControlledDocumentedTypeDef.value.value))
+            } : ((morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[scala.Unit]]])) => ((morphir.ir.Path.Path, morphir.ir.Module.ModuleName, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])))(morphir.sdk.Dict.toList(accessControlledModuleDef.value.types))
+        } : ((morphir.ir.Module.ModuleName, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]])) => morphir.sdk.List.List[((morphir.ir.Path.Path, morphir.ir.Module.ModuleName, morphir.ir.Name.Name), morphir.ir.Type.Specification[scala.Unit])]))(morphir.sdk.Dict.toList(packageDef.modules)))
+
+        morphir.sdk.Dict.union(typeSpecsInDependencies)(typeSpecsInPackage)
+      }
     } : morphir.ir.Distribution.Distribution => morphir.sdk.Dict.Dict[morphir.ir.FQName.FQName, morphir.ir.Type.Specification[scala.Unit]])
 
 }

--- a/morphir/ir/src/morphir/ir/FQName.scala
+++ b/morphir/ir/src/morphir/ir/FQName.scala
@@ -37,7 +37,7 @@ object FQName{
     splitter: morphir.sdk.String.String
   ): morphir.ir.FQName.FQName =
     morphir.sdk.String.split(splitter)(fqNameString) match {
-      case moduleNameString :: packageNameString :: localNameString :: Nil => 
+      case (moduleNameString :: (packageNameString :: (localNameString :: Nil))) => 
         (morphir.ir.Path.fromString(moduleNameString), morphir.ir.Path.fromString(packageNameString), morphir.ir.Name.fromString(localNameString))
       case _ => 
         (morphir.sdk.List(morphir.sdk.List(
@@ -55,7 +55,7 @@ object FQName{
     separator: morphir.sdk.String.String
   ): morphir.sdk.Result.Result[morphir.sdk.String.String, morphir.ir.FQName.FQName] =
     morphir.sdk.String.split(separator)(fqNameString) match {
-      case moduleNameString :: packageNameString :: localNameString :: Nil => 
+      case (moduleNameString :: (packageNameString :: (localNameString :: Nil))) => 
         (morphir.sdk.Result.Ok((morphir.ir.Path.fromString(moduleNameString), morphir.ir.Path.fromString(packageNameString), morphir.ir.Name.fromString(localNameString))) : morphir.sdk.Result.Result[morphir.sdk.String.String, morphir.ir.FQName.FQName])
       case parts => 
         (morphir.sdk.Result.Err(morphir.sdk.String.concat(morphir.sdk.List(

--- a/morphir/ir/src/morphir/ir/FormatVersion.scala
+++ b/morphir/ir/src/morphir/ir/FormatVersion.scala
@@ -8,5 +8,8 @@ object FormatVersion{
     formatVersion: morphir.sdk.Basics.Int,
     distribution: morphir.ir.Distribution.Distribution
   ){}
+  
+  def currentFormatVersion: morphir.sdk.Basics.Int =
+    morphir.sdk.Basics.Int(3)
 
 }

--- a/morphir/ir/src/morphir/ir/Literal.scala
+++ b/morphir/ir/src/morphir/ir/Literal.scala
@@ -13,27 +13,27 @@ object Literal{
   object Literal{
   
     final case class BoolLiteral(
-      arg1: morphir.sdk.Basics.Bool
+      value: morphir.sdk.Basics.Bool
     ) extends morphir.ir.Literal.Literal{}
     
     final case class CharLiteral(
-      arg1: morphir.sdk.Char.Char
+      value: morphir.sdk.Char.Char
     ) extends morphir.ir.Literal.Literal{}
     
     final case class DecimalLiteral(
-      arg1: morphir.sdk.Decimal.Decimal
+      value: morphir.sdk.Decimal.Decimal
     ) extends morphir.ir.Literal.Literal{}
     
     final case class FloatLiteral(
-      arg1: morphir.sdk.Basics.Float
+      value: morphir.sdk.Basics.Float
     ) extends morphir.ir.Literal.Literal{}
     
     final case class StringLiteral(
-      arg1: morphir.sdk.String.String
+      value: morphir.sdk.String.String
     ) extends morphir.ir.Literal.Literal{}
     
     final case class WholeNumberLiteral(
-      arg1: morphir.sdk.Basics.Int
+      value: morphir.sdk.Basics.Int
     ) extends morphir.ir.Literal.Literal{}
   
   }
@@ -60,19 +60,24 @@ object Literal{
   ): morphir.ir.Literal.Literal =
     (morphir.ir.Literal.CharLiteral(value) : morphir.ir.Literal.Literal)
   
+  def decimalLiteral(
+    value: morphir.sdk.Decimal.Decimal
+  ): morphir.ir.Literal.Literal =
+    (morphir.ir.Literal.DecimalLiteral(value) : morphir.ir.Literal.Literal)
+  
   def floatLiteral(
     value: morphir.sdk.Basics.Float
   ): morphir.ir.Literal.Literal =
     (morphir.ir.Literal.FloatLiteral(value) : morphir.ir.Literal.Literal)
   
-  def intLiteral(
-    value: morphir.sdk.Basics.Int
-  ): morphir.ir.Literal.Literal =
-    (morphir.ir.Literal.WholeNumberLiteral(value) : morphir.ir.Literal.Literal)
-  
   def stringLiteral(
     value: morphir.sdk.String.String
   ): morphir.ir.Literal.Literal =
     (morphir.ir.Literal.StringLiteral(value) : morphir.ir.Literal.Literal)
+  
+  def wholeNumberLiteral(
+    value: morphir.sdk.Basics.Int
+  ): morphir.ir.Literal.Literal =
+    (morphir.ir.Literal.WholeNumberLiteral(value) : morphir.ir.Literal.Literal)
 
 }

--- a/morphir/ir/src/morphir/ir/Module.scala
+++ b/morphir/ir/src/morphir/ir/Module.scala
@@ -1,167 +1,167 @@
 package morphir.ir
 
 /** Generated based on IR.Module
-*/
+ */
 object Module{
 
   final case class Definition[Ta, Va](
-    types: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Ta]]]],
-    values: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]]],
-    doc: morphir.sdk.Maybe.Maybe[morphir.sdk.String.String]
-  ){}
-  
+                                       types: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Ta]]]],
+                                       values: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]]],
+                                       doc: morphir.sdk.Maybe.Maybe[morphir.sdk.String.String]
+                                     ){}
+
   type ModuleName = morphir.ir.Path.Path
-  
+
   type QualifiedModuleName = (morphir.ir.Path.Path, morphir.ir.Path.Path)
-  
+
   final case class Specification[Ta](
-    types: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Type.Specification[Ta]]],
-    values: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Value.Specification[Ta]]],
-    doc: morphir.sdk.Maybe.Maybe[morphir.sdk.String.String]
-  ){}
-  
+                                      types: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Type.Specification[Ta]]],
+                                      values: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Value.Specification[Ta]]],
+                                      doc: morphir.sdk.Maybe.Maybe[morphir.sdk.String.String]
+                                    ){}
+
   def collectReferences[Ta, Va](
-    moduleDef: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.sdk.Set.Set[morphir.ir.FQName.FQName] =
+                                 moduleDef: morphir.ir.Module.Definition[Ta, Va]
+                               ): morphir.sdk.Set.Set[morphir.ir.FQName.FQName] =
     morphir.sdk.Set.union(morphir.ir.Module.collectTypeReferences(moduleDef))(morphir.ir.Module.collectValueReferences(moduleDef))
-  
+
   def collectTypeReferences[Ta, Va](
-    moduleDef: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.sdk.Set.Set[morphir.ir.FQName.FQName] = {
+                                     moduleDef: morphir.ir.Module.Definition[Ta, Va]
+                                   ): morphir.sdk.Set.Set[morphir.ir.FQName.FQName] = {
     val typeRefs: morphir.sdk.Set.Set[morphir.ir.FQName.FQName] = morphir.sdk.List.foldl(morphir.sdk.Set.union[FQName.FQName])(morphir.sdk.Set.empty)(morphir.sdk.List.map(((typeDef: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Ta]]]) =>
       typeDef.value.value match {
-        case morphir.ir.Type.TypeAliasDefinition(_, tpe) => 
+        case morphir.ir.Type.TypeAliasDefinition(_, tpe) =>
           morphir.ir.Type.collectReferences(tpe)
-        case morphir.ir.Type.CustomTypeDefinition(_, ctors) => 
+        case morphir.ir.Type.CustomTypeDefinition(_, ctors) =>
           morphir.sdk.List.foldl(morphir.sdk.Set.union[FQName.FQName])(morphir.sdk.Set.empty)(morphir.sdk.List.concatMap(((ctorArgs: morphir.sdk.List.List[(morphir.ir.Name.Name, morphir.ir.Type.Type[Ta])]) =>
             morphir.sdk.List.map(({
-              case (_, tpe) => 
+              case (_, tpe) =>
                 morphir.ir.Type.collectReferences(tpe)
             } : ((morphir.ir.Name.Name, morphir.ir.Type.Type[Ta])) => morphir.sdk.Set.Set[morphir.ir.FQName.FQName]))(ctorArgs)))(morphir.sdk.Dict.values(ctors.value)))
       }))(morphir.sdk.Dict.values(moduleDef.types)))
-    
+
     val valueRefs: morphir.sdk.Set.Set[morphir.ir.FQName.FQName] = morphir.sdk.List.foldl(morphir.sdk.Set.union[FQName.FQName])(morphir.sdk.Set.empty)(morphir.sdk.List.concatMap(((valueDef: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]]) =>
       morphir.sdk.List.map(morphir.ir.Type.collectReferences[Ta])(morphir.sdk.List.cons(valueDef.value.value.outputType)(morphir.sdk.List.map(({
-        case (_, _, tpe) => 
+        case (_, _, tpe) =>
           tpe
       } : ((morphir.ir.Name.Name, Va, morphir.ir.Type.Type[Ta])) => morphir.ir.Type.Type[Ta]))(valueDef.value.value.inputTypes)))))(morphir.sdk.Dict.values(moduleDef.values)))
-    
+
     morphir.sdk.Set.union(typeRefs)(valueRefs)
   }
-  
+
   def collectValueReferences[Ta, Va](
-    moduleDef: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.sdk.Set.Set[morphir.ir.FQName.FQName] =
+                                      moduleDef: morphir.ir.Module.Definition[Ta, Va]
+                                    ): morphir.sdk.Set.Set[morphir.ir.FQName.FQName] =
     morphir.sdk.List.foldl(morphir.sdk.Set.union[FQName.FQName])(morphir.sdk.Set.empty)(morphir.sdk.List.map(((valueDef: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]]) =>
       morphir.ir.Value.collectReferences(valueDef.value.value.body)))(morphir.sdk.Dict.values(moduleDef.values)))
-  
+
   def definitionToSpecification[Ta, Va](
-    _def: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.ir.Module.Specification[Ta] =
+                                         _def: morphir.ir.Module.Definition[Ta, Va]
+                                       ): morphir.ir.Module.Specification[Ta] =
     morphir.ir.Module.Specification(
       doc = _def.doc,
       types = morphir.sdk.Dict.fromList(morphir.sdk.List.filterMap(({
-        case (path, accessControlledType) => 
+        case (path, accessControlledType) =>
           morphir.sdk.Maybe.map(((typeDef: morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Ta]]) =>
             (path, morphir.ir.Documented.map(morphir.ir.Type.definitionToSpecification[Ta])(typeDef))))(morphir.ir.AccessControlled.withPublicAccess(accessControlledType))
       } : ((morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Ta]]])) => morphir.sdk.Maybe.Maybe[(morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Type.Specification[Ta]])]))(morphir.sdk.Dict.toList(_def.types))),
       values = morphir.sdk.Dict.fromList(morphir.sdk.List.filterMap(({
-        case (path, accessControlledValue) => 
+        case (path, accessControlledValue) =>
           morphir.sdk.Maybe.map(((valueDef: morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]) =>
             (path, morphir.ir.Documented.map(morphir.ir.Value.definitionToSpecification[Ta, Va])(valueDef))))(morphir.ir.AccessControlled.withPublicAccess(accessControlledValue))
       } : ((morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]])) => morphir.sdk.Maybe.Maybe[(morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Value.Specification[Ta]])]))(morphir.sdk.Dict.toList(_def.values)))
     )
-  
+
   def definitionToSpecificationWithPrivate[Ta, Va](
-    _def: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.ir.Module.Specification[Ta] =
+                                                    _def: morphir.ir.Module.Definition[Ta, Va]
+                                                  ): morphir.ir.Module.Specification[Ta] =
     morphir.ir.Module.Specification(
       doc = _def.doc,
       types = morphir.sdk.Dict.fromList(morphir.sdk.List.map(({
-        case (path, accessControlledType) => 
+        case (path, accessControlledType) =>
           (path, morphir.ir.Documented.map(morphir.ir.Type.definitionToSpecificationWithPrivate[Ta])(morphir.ir.AccessControlled.withPrivateAccess(accessControlledType)))
       } : ((morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Ta]]])) => (morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Type.Specification[Ta]])))(morphir.sdk.Dict.toList(_def.types))),
       values = morphir.sdk.Dict.fromList(morphir.sdk.List.map(({
-        case (path, accessControlledValue) => 
+        case (path, accessControlledValue) =>
           (path, morphir.ir.Documented.map(morphir.ir.Value.definitionToSpecification[Ta, Va])(morphir.ir.AccessControlled.withPrivateAccess(accessControlledValue)))
       } : ((morphir.ir.Name.Name, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]])) => (morphir.ir.Name.Name, morphir.ir.Documented.Documented[morphir.ir.Value.Specification[Ta]])))(morphir.sdk.Dict.toList(_def.values)))
     )
-  
+
   def dependsOnModules[Ta, Va](
-    moduleDef: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.sdk.Set.Set[morphir.ir.Module.QualifiedModuleName] =
+                                moduleDef: morphir.ir.Module.Definition[Ta, Va]
+                              ): morphir.sdk.Set.Set[morphir.ir.Module.QualifiedModuleName] =
     morphir.sdk.Set.map(({
-      case (packageName, moduleName, _) => 
+      case (packageName, moduleName, _) =>
         (packageName, moduleName)
     } : ((morphir.ir.Path.Path, morphir.ir.Path.Path, morphir.ir.Name.Name)) => morphir.ir.Module.QualifiedModuleName))(morphir.ir.Module.collectReferences(moduleDef))
-  
+
   def emptyDefinition[Ta, Va]: morphir.ir.Module.Definition[Ta, Va] =
     morphir.ir.Module.Definition(
       doc = (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[morphir.sdk.String.String]),
       types = morphir.sdk.Dict.empty,
       values = morphir.sdk.Dict.empty
     )
-  
+
   def emptySpecification[Ta]: morphir.ir.Module.Specification[Ta] =
     morphir.ir.Module.Specification(
       doc = (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[morphir.sdk.String.String]),
       types = morphir.sdk.Dict.empty,
       values = morphir.sdk.Dict.empty
     )
-  
+
   def eraseDefinitionAttributes[Ta, Va](
-    _def: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.ir.Module.Definition[scala.Unit, scala.Unit] =
+                                         _def: morphir.ir.Module.Definition[Ta, Va]
+                                       ): morphir.ir.Module.Definition[scala.Unit, scala.Unit] =
     morphir.ir.Module.mapDefinitionAttributes(({
-      case _ => 
-        {}
+      case _ =>
+      {}
     } : Ta => scala.Unit))(({
-      case _ => 
-        {}
+      case _ =>
+      {}
     } : Va => scala.Unit))(_def)
-  
+
   def eraseSpecificationAttributes[Ta](
-    spec: morphir.ir.Module.Specification[Ta]
-  ): morphir.ir.Module.Specification[scala.Unit] =
+                                        spec: morphir.ir.Module.Specification[Ta]
+                                      ): morphir.ir.Module.Specification[scala.Unit] =
     morphir.ir.Module.mapSpecificationAttributes(({
-      case _ => 
-        {}
+      case _ =>
+      {}
     } : Ta => scala.Unit))(spec)
-  
+
   def lookupTypeSpecification[Ta](
-    localName: morphir.ir.Name.Name
-  )(
-    moduleSpec: morphir.ir.Module.Specification[Ta]
-  ): morphir.sdk.Maybe.Maybe[morphir.ir.Type.Specification[Ta]] =
+                                   localName: morphir.ir.Name.Name
+                                 )(
+                                   moduleSpec: morphir.ir.Module.Specification[Ta]
+                                 ): morphir.sdk.Maybe.Maybe[morphir.ir.Type.Specification[Ta]] =
     morphir.sdk.Maybe.map(((x: morphir.ir.Documented.Documented[morphir.ir.Type.Specification[Ta]]) =>
       x.value))(morphir.sdk.Dict.get(localName)(moduleSpec.types))
-  
+
   def lookupValueDefinition[Ta, Va](
-    localName: morphir.ir.Name.Name
-  )(
-    moduleDef: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.sdk.Maybe.Maybe[morphir.ir.Value.Definition[Ta, Va]] =
+                                     localName: morphir.ir.Name.Name
+                                   )(
+                                     moduleDef: morphir.ir.Module.Definition[Ta, Va]
+                                   ): morphir.sdk.Maybe.Maybe[morphir.ir.Value.Definition[Ta, Va]] =
     morphir.sdk.Maybe.map(morphir.sdk.Basics.composeRight(morphir.ir.AccessControlled.withPrivateAccess[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]])(((x: morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]) =>
       x.value)))(morphir.sdk.Dict.get(localName)(moduleDef.values))
-  
+
   def lookupValueSpecification[Ta](
-    localName: morphir.ir.Name.Name
-  )(
-    moduleSpec: morphir.ir.Module.Specification[Ta]
-  ): morphir.sdk.Maybe.Maybe[morphir.ir.Value.Specification[Ta]] =
+                                    localName: morphir.ir.Name.Name
+                                  )(
+                                    moduleSpec: morphir.ir.Module.Specification[Ta]
+                                  ): morphir.sdk.Maybe.Maybe[morphir.ir.Value.Specification[Ta]] =
     morphir.sdk.Maybe.map(((x: morphir.ir.Documented.Documented[morphir.ir.Value.Specification[Ta]]) =>
       x.value))(morphir.sdk.Dict.get(localName)(moduleSpec.values))
-  
+
   def mapDefinitionAttributes[Ta, Tb, Va, Vb](
-    tf: Ta => Tb
-  )(
-    vf: Va => Vb
-  )(
-    _def: morphir.ir.Module.Definition[Ta, Va]
-  ): morphir.ir.Module.Definition[Tb, Vb] =
+                                               tf: Ta => Tb
+                                             )(
+                                               vf: Va => Vb
+                                             )(
+                                               _def: morphir.ir.Module.Definition[Ta, Va]
+                                             ): morphir.ir.Module.Definition[Tb, Vb] =
     (morphir.ir.Module.Definition(
       morphir.sdk.Dict.map(({
-        case _ => 
+        case _ =>
           ((typeDef: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Ta]]]) =>
             (morphir.ir.AccessControlled.AccessControlled(
               typeDef.access,
@@ -169,7 +169,7 @@ object Module{
             ) : morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Tb]]]))
       } : morphir.ir.Name.Name => morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Ta]]] => morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Type.Definition[Tb]]]))(_def.types),
       morphir.sdk.Dict.map(({
-        case _ => 
+        case _ =>
           ((valueDef: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]]) =>
             (morphir.ir.AccessControlled.AccessControlled(
               valueDef.access,
@@ -178,20 +178,20 @@ object Module{
       } : morphir.ir.Name.Name => morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Ta, Va]]] => morphir.ir.AccessControlled.AccessControlled[morphir.ir.Documented.Documented[morphir.ir.Value.Definition[Tb, Vb]]]))(_def.values),
       _def.doc
     ) : morphir.ir.Module.Definition[Tb, Vb])
-  
+
   def mapSpecificationAttributes[Ta, Tb](
-    tf: Ta => Tb
-  )(
-    spec: morphir.ir.Module.Specification[Ta]
-  ): morphir.ir.Module.Specification[Tb] =
+                                          tf: Ta => Tb
+                                        )(
+                                          spec: morphir.ir.Module.Specification[Ta]
+                                        ): morphir.ir.Module.Specification[Tb] =
     (morphir.ir.Module.Specification(
       morphir.sdk.Dict.map(({
-        case _ => 
+        case _ =>
           ((typeSpec: morphir.ir.Documented.Documented[morphir.ir.Type.Specification[Ta]]) =>
             morphir.ir.Documented.map(morphir.ir.Type.mapSpecificationAttributes(tf))(typeSpec))
       } : morphir.ir.Name.Name => morphir.ir.Documented.Documented[morphir.ir.Type.Specification[Ta]] => morphir.ir.Documented.Documented[morphir.ir.Type.Specification[Tb]]))(spec.types),
       morphir.sdk.Dict.map(({
-        case _ => 
+        case _ =>
           ((valueSpec: morphir.ir.Documented.Documented[morphir.ir.Value.Specification[Ta]]) =>
             morphir.ir.Documented.map(morphir.ir.Value.mapSpecificationAttributes(tf))(valueSpec))
       } : morphir.ir.Name.Name => morphir.ir.Documented.Documented[morphir.ir.Value.Specification[Ta]] => morphir.ir.Documented.Documented[morphir.ir.Value.Specification[Tb]]))(spec.values),

--- a/morphir/ir/src/morphir/ir/Name.scala
+++ b/morphir/ir/src/morphir/ir/Name.scala
@@ -36,7 +36,7 @@ object Name{
     morphir.ir.Name.toList(name) match {
       case Nil => 
         """"""
-      case head :: tail => 
+      case (head :: tail) => 
         morphir.sdk.String.join("""""")(morphir.sdk.List.cons(head)(morphir.sdk.List.map(morphir.ir.Name.capitalize)(tail)))
     }
   
@@ -65,7 +65,7 @@ object Name{
             } else {
               morphir.sdk.List.append(prefix)(morphir.sdk.List(join(abbrev)))
             }
-          case first :: rest => 
+          case (first :: rest) => 
             if (morphir.sdk.Basics.equal(morphir.sdk.String.length(first))(morphir.sdk.Basics.Int(1))) {
               process(prefix)(morphir.sdk.List.append(abbrev)(morphir.sdk.List(first)))(rest)
             } else {
@@ -86,7 +86,7 @@ object Name{
         }
       
       name match {
-        case word :: Nil => 
+        case (word :: Nil) => 
           if (morphir.sdk.Basics.equal(morphir.sdk.String.length(word))(morphir.sdk.Basics.Int(1))) {
             name
           } else {
@@ -110,7 +110,7 @@ object Name{
     name: morphir.ir.Name.Name
   ): morphir.sdk.List.List[morphir.sdk.String.String] =
     morphir.ir.Name.toHumanWords(name) match {
-      case firstWord :: rest => 
+      case (firstWord :: rest) => 
         morphir.sdk.List.cons(morphir.ir.Name.capitalize(firstWord))(rest)
       case Nil => 
         morphir.sdk.List(

--- a/morphir/ir/src/morphir/ir/Package.scala
+++ b/morphir/ir/src/morphir/ir/Package.scala
@@ -1,11 +1,8 @@
 package morphir.ir
 
-
 /** Generated based on IR.Package
 */
 object Package{
-
-  implicit def moduleNameOrdering: Ordering[Module.ModuleName] = (_: Module.ModuleName, _: Module.ModuleName) => 0
 
   final case class Definition[Ta, Va](
     modules: morphir.sdk.Dict.Dict[morphir.ir.Module.ModuleName, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[Ta, Va]]]
@@ -65,114 +62,114 @@ object Package{
     packageDef: morphir.ir.Package.Definition[Ta, Va]
   ): morphir.sdk.Maybe.Maybe[morphir.ir.Module.Definition[Ta, Va]] =
     morphir.sdk.Maybe.map(morphir.ir.AccessControlled.withPrivateAccess[morphir.ir.Module.Definition[Ta, Va]])(morphir.sdk.Dict.get(modulePath)(packageDef.modules))
-  
+
   def lookupModuleSpecification[Ta](
-    modulePath: morphir.ir.Path.Path
-  )(
-    packageSpec: morphir.ir.Package.Specification[Ta]
-  ): morphir.sdk.Maybe.Maybe[morphir.ir.Module.Specification[Ta]] =
+                                     modulePath: morphir.ir.Path.Path
+                                   )(
+                                     packageSpec: morphir.ir.Package.Specification[Ta]
+                                   ): morphir.sdk.Maybe.Maybe[morphir.ir.Module.Specification[Ta]] =
     morphir.sdk.Dict.get(modulePath)(packageSpec.modules)
-  
+
   def lookupTypeSpecification[Ta](
-    modulePath: morphir.ir.Path.Path
-  )(
-    localName: morphir.ir.Name.Name
-  )(
-    packageSpec: morphir.ir.Package.Specification[Ta]
-  ): morphir.sdk.Maybe.Maybe[morphir.ir.Type.Specification[Ta]] =
+                                   modulePath: morphir.ir.Path.Path
+                                 )(
+                                   localName: morphir.ir.Name.Name
+                                 )(
+                                   packageSpec: morphir.ir.Package.Specification[Ta]
+                                 ): morphir.sdk.Maybe.Maybe[morphir.ir.Type.Specification[Ta]] =
     morphir.sdk.Maybe.andThen[Module.Specification[Ta], Type.Specification[Ta]](morphir.ir.Module.lookupTypeSpecification(localName))(morphir.ir.Package.lookupModuleSpecification(modulePath)(packageSpec))
-  
+
   def lookupValueDefinition[Ta, Va](
-    modulePath: morphir.ir.Path.Path
-  )(
-    localName: morphir.ir.Name.Name
-  )(
-    packageDef: morphir.ir.Package.Definition[Ta, Va]
-  ): morphir.sdk.Maybe.Maybe[morphir.ir.Value.Definition[Ta, Va]] =
+                                     modulePath: morphir.ir.Path.Path
+                                   )(
+                                     localName: morphir.ir.Name.Name
+                                   )(
+                                     packageDef: morphir.ir.Package.Definition[Ta, Va]
+                                   ): morphir.sdk.Maybe.Maybe[morphir.ir.Value.Definition[Ta, Va]] =
     morphir.sdk.Maybe.andThen[Module.Definition[Ta, Va], Value.Definition[Ta, Va]](morphir.ir.Module.lookupValueDefinition(localName))(morphir.ir.Package.lookupModuleDefinition(modulePath)(packageDef))
-  
+
   def lookupValueSpecification[Ta](
-    modulePath: morphir.ir.Path.Path
-  )(
-    localName: morphir.ir.Name.Name
-  )(
-    packageSpec: morphir.ir.Package.Specification[Ta]
-  ): morphir.sdk.Maybe.Maybe[morphir.ir.Value.Specification[Ta]] =
+                                    modulePath: morphir.ir.Path.Path
+                                  )(
+                                    localName: morphir.ir.Name.Name
+                                  )(
+                                    packageSpec: morphir.ir.Package.Specification[Ta]
+                                  ): morphir.sdk.Maybe.Maybe[morphir.ir.Value.Specification[Ta]] =
     morphir.sdk.Maybe.andThen[Module.Specification[Ta], Value.Specification[Ta]](morphir.ir.Module.lookupValueSpecification(localName))(morphir.ir.Package.lookupModuleSpecification(modulePath)(packageSpec))
-  
+
   def mapDefinitionAttributes[Ta, Tb, Va, Vb](
-    tf: Ta => Tb
-  )(
-    vf: Va => Vb
-  )(
-    _def: morphir.ir.Package.Definition[Ta, Va]
-  ): morphir.ir.Package.Definition[Tb, Vb] =
+                                               tf: Ta => Tb
+                                             )(
+                                               vf: Va => Vb
+                                             )(
+                                               _def: morphir.ir.Package.Definition[Ta, Va]
+                                             ): morphir.ir.Package.Definition[Tb, Vb] =
     (morphir.ir.Package.Definition(morphir.sdk.Dict.map(({
-      case _ => 
+      case _ =>
         ((moduleDef: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[Ta, Va]]) =>
           (morphir.ir.AccessControlled.AccessControlled(
             moduleDef.access,
             morphir.ir.Module.mapDefinitionAttributes(tf)(vf)(moduleDef.value)
           ) : morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[Tb, Vb]]))
     } : morphir.ir.Module.ModuleName => morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[Ta, Va]] => morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[Tb, Vb]]))(_def.modules)) : morphir.ir.Package.Definition[Tb, Vb])
-  
+
   def mapSpecificationAttributes[Ta, Tb](
-    tf: Ta => Tb
-  )(
-    spec: morphir.ir.Package.Specification[Ta]
-  ): morphir.ir.Package.Specification[Tb] =
+                                          tf: Ta => Tb
+                                        )(
+                                          spec: morphir.ir.Package.Specification[Ta]
+                                        ): morphir.ir.Package.Specification[Tb] =
     (morphir.ir.Package.Specification(morphir.sdk.Dict.map(({
-      case _ => 
+      case _ =>
         ((moduleSpec: morphir.ir.Module.Specification[Ta]) =>
           morphir.ir.Module.mapSpecificationAttributes(tf)(moduleSpec))
     } : morphir.ir.Module.ModuleName => morphir.ir.Module.Specification[Ta] => morphir.ir.Module.Specification[Tb]))(spec.modules)) : morphir.ir.Package.Specification[Tb])
-  
+
   def modulesOrderedByDependency(
-    packageName: morphir.ir.Package.PackageName
-  )(
-    packageDef: morphir.ir.Package.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]
-  ): morphir.sdk.Result.Result[morphir.dependency.DAG.CycleDetected[morphir.ir.Module.ModuleName], morphir.sdk.List.List[(morphir.ir.Module.ModuleName, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]])]] =
+                                  packageName: morphir.ir.Package.PackageName
+                                )(
+                                  packageDef: morphir.ir.Package.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]
+                                ): morphir.sdk.Result.Result[morphir.dependency.DAG.CycleDetected[morphir.ir.Module.ModuleName], morphir.sdk.List.List[(morphir.ir.Module.ModuleName, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]])]] =
     morphir.sdk.Result.map(((moduleDependencies: morphir.dependency.DAG.DAG[morphir.ir.Path.Path]) =>
       morphir.sdk.List.filterMap(((moduleName: morphir.ir.Path.Path) =>
         morphir.sdk.Maybe.map[AccessControlled.AccessControlled[Module.Definition[Unit, Type.Type[Unit]]], (Module.ModuleName, AccessControlled.AccessControlled[Module.Definition[Unit, Type.Type[Unit]]])](morphir.sdk.Tuple.pair(moduleName))(morphir.sdk.Dict.get(moduleName)(packageDef.modules))))(morphir.sdk.List.concat(morphir.dependency.DAG.backwardTopologicalOrdering(moduleDependencies)))))(morphir.sdk.List.foldl(({
-      case (moduleName, accessControlledModuleDef) => 
+      case (moduleName, accessControlledModuleDef) =>
         ((dagResultSoFar: morphir.sdk.Result.Result[morphir.dependency.DAG.CycleDetected[morphir.ir.Path.Path], morphir.dependency.DAG.DAG[morphir.ir.Path.Path]]) =>
-          {
-            val dependsOnModules: morphir.sdk.Set.Set[morphir.ir.Module.ModuleName] = morphir.sdk.Set.map(morphir.sdk.Tuple.second[Module.ModuleName, Module.ModuleName])(morphir.sdk.Set.filter(({
-              case (dependsOnPackage, _) => 
-                morphir.sdk.Basics.equal(dependsOnPackage)(packageName)
-            } : ((morphir.ir.Path.Path, morphir.ir.Path.Path)) => morphir.sdk.Basics.Bool))(morphir.ir.Module.dependsOnModules(accessControlledModuleDef.value)))
-            
-            morphir.sdk.Result.andThen(morphir.dependency.DAG.insertNode(moduleName)(dependsOnModules))(dagResultSoFar)
-          })
+        {
+          val dependsOnModules: morphir.sdk.Set.Set[morphir.ir.Module.ModuleName] = morphir.sdk.Set.map(morphir.sdk.Tuple.second[Module.ModuleName, Module.ModuleName])(morphir.sdk.Set.filter(({
+            case (dependsOnPackage, _) =>
+              morphir.sdk.Basics.equal(dependsOnPackage)(packageName)
+          } : ((morphir.ir.Path.Path, morphir.ir.Path.Path)) => morphir.sdk.Basics.Bool))(morphir.ir.Module.dependsOnModules(accessControlledModuleDef.value)))
+
+          morphir.sdk.Result.andThen(morphir.dependency.DAG.insertNode(moduleName)(dependsOnModules))(dagResultSoFar)
+        })
     } : ((morphir.ir.Path.Path, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[scala.Unit, morphir.ir.Type.Type[scala.Unit]]])) => morphir.sdk.Result.Result[morphir.dependency.DAG.CycleDetected[morphir.ir.Path.Path], morphir.dependency.DAG.DAG[morphir.ir.Path.Path]] => morphir.sdk.Result.Result[morphir.dependency.DAG.CycleDetected[morphir.ir.Path.Path], morphir.dependency.DAG.DAG[morphir.ir.Path.Path]]))((morphir.sdk.Result.Ok(morphir.dependency.DAG.empty) : morphir.sdk.Result.Result[morphir.dependency.DAG.CycleDetected[morphir.ir.Path.Path], morphir.dependency.DAG.DAG[morphir.ir.Path.Path]]))(morphir.sdk.Dict.toList(packageDef.modules)))
-  
+
   def selectModules[Ta, Va](
-    modulesToInclude: morphir.sdk.Set.Set[morphir.ir.Module.ModuleName]
-  )(
-    packageName: morphir.ir.Package.PackageName
-  )(
-    packageDef: morphir.ir.Package.Definition[Ta, Va]
-  ): morphir.ir.Package.Definition[Ta, Va] = {
+                             modulesToInclude: morphir.sdk.Set.Set[morphir.ir.Module.ModuleName]
+                           )(
+                             packageName: morphir.ir.Package.PackageName
+                           )(
+                             packageDef: morphir.ir.Package.Definition[Ta, Va]
+                           ): morphir.ir.Package.Definition[Ta, Va] = {
     def findAllDependencies(
-      current: morphir.sdk.Set.Set[morphir.ir.Module.ModuleName]
-    ): morphir.sdk.Set.Set[morphir.ir.Module.ModuleName] =
+                             current: morphir.sdk.Set.Set[morphir.ir.Module.ModuleName]
+                           ): morphir.sdk.Set.Set[morphir.ir.Module.ModuleName] =
       morphir.sdk.List.foldl(morphir.sdk.Set.union[Module.ModuleName])(morphir.sdk.Set.empty)(morphir.sdk.List.filterMap(((currentModuleName: morphir.ir.Module.ModuleName) =>
         morphir.sdk.Maybe.map(((mDef: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[Ta, Va]]) =>
           morphir.sdk.Set.fromList(morphir.sdk.List.filterMap(({
-            case (pName, mName) => 
+            case (pName, mName) =>
               if (morphir.sdk.Basics.equal(pName)(packageName)) {
                 (morphir.sdk.Maybe.Just(mName) : morphir.sdk.Maybe.Maybe[morphir.ir.Path.Path])
               } else {
                 (morphir.sdk.Maybe.Nothing : morphir.sdk.Maybe.Maybe[morphir.ir.Path.Path])
               }
           } : ((morphir.ir.Path.Path, morphir.ir.Path.Path)) => morphir.sdk.Maybe.Maybe[morphir.ir.Path.Path]))(morphir.sdk.Set.toList(morphir.ir.Module.dependsOnModules(mDef.value))))))(morphir.sdk.Dict.get(currentModuleName)(packageDef.modules))))(morphir.sdk.Set.toList(current)))
-    
+
     val expandedModulesToInclude: morphir.sdk.Set.Set[morphir.ir.Module.ModuleName] = morphir.sdk.Set.union(findAllDependencies(modulesToInclude))(modulesToInclude)
-    
+
     if (morphir.sdk.Basics.equal(modulesToInclude)(expandedModulesToInclude)) {
       packageDef.copy(modules = morphir.sdk.Dict.fromList(morphir.sdk.List.filter(({
-        case (moduleName, _) => 
+        case (moduleName, _) =>
           morphir.sdk.Set.member(moduleName)(modulesToInclude)
       } : ((morphir.ir.Module.ModuleName, morphir.ir.AccessControlled.AccessControlled[morphir.ir.Module.Definition[Ta, Va]])) => morphir.sdk.Basics.Bool))(morphir.sdk.Dict.toList(packageDef.modules))))
     } else {

--- a/morphir/ir/src/morphir/ir/Path.scala
+++ b/morphir/ir/src/morphir/ir/Path.scala
@@ -29,7 +29,7 @@ object Path{
         true
       case (_, Nil) => 
         false
-      case (pathHead :: pathTail, prefixHead :: prefixTail) => 
+      case ((pathHead :: pathTail), (prefixHead :: prefixTail)) => 
         if (morphir.sdk.Basics.equal(prefixHead)(pathHead)) {
           morphir.ir.Path.isPrefixOf(prefixTail)(pathTail)
         } else {

--- a/morphir/ir/src/morphir/ir/QName.scala
+++ b/morphir/ir/src/morphir/ir/QName.scala
@@ -23,7 +23,7 @@ object QName{
     qNameString: morphir.sdk.String.String
   ): morphir.sdk.Maybe.Maybe[morphir.ir.QName.QName] =
     morphir.sdk.String.split(""":""")(qNameString) match {
-      case packageNameString :: localNameString :: Nil => 
+      case (packageNameString :: (localNameString :: Nil)) => 
         (morphir.sdk.Maybe.Just((morphir.ir.QName.QName(
           morphir.ir.Path.fromString(packageNameString),
           morphir.ir.Name.fromString(localNameString)

--- a/morphir/ir/src/morphir/ir/Type.scala
+++ b/morphir/ir/src/morphir/ir/Type.scala
@@ -19,13 +19,13 @@ object Type{
   object Definition{
   
     final case class CustomTypeDefinition[A](
-      arg1: morphir.sdk.List.List[morphir.ir.Name.Name],
-      arg2: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Type.Constructors[A]]
+      typeParams: morphir.sdk.List.List[morphir.ir.Name.Name],
+      ctors: morphir.ir.AccessControlled.AccessControlled[morphir.ir.Type.Constructors[A]]
     ) extends morphir.ir.Type.Definition[A]{}
     
     final case class TypeAliasDefinition[A](
-      arg1: morphir.sdk.List.List[morphir.ir.Name.Name],
-      arg2: morphir.ir.Type.Type[A]
+      typeParams: morphir.sdk.List.List[morphir.ir.Name.Name],
+      typeExp: morphir.ir.Type.Type[A]
     ) extends morphir.ir.Type.Definition[A]{}
   
   }
@@ -54,22 +54,22 @@ object Type{
   object Specification{
   
     final case class CustomTypeSpecification[A](
-      arg1: morphir.sdk.List.List[morphir.ir.Name.Name],
-      arg2: morphir.ir.Type.Constructors[A]
+      typeParams: morphir.sdk.List.List[morphir.ir.Name.Name],
+      ctors: morphir.ir.Type.Constructors[A]
     ) extends morphir.ir.Type.Specification[A]{}
     
     final case class DerivedTypeSpecification[A](
-      arg1: morphir.sdk.List.List[morphir.ir.Name.Name],
-      arg2: morphir.ir.Type.DerivedTypeSpecificationDetails[A]
+      typeParams: morphir.sdk.List.List[morphir.ir.Name.Name],
+      details: morphir.ir.Type.DerivedTypeSpecificationDetails[A]
     ) extends morphir.ir.Type.Specification[A]{}
     
     final case class OpaqueTypeSpecification[A](
-      arg1: morphir.sdk.List.List[morphir.ir.Name.Name]
+      typeParams: morphir.sdk.List.List[morphir.ir.Name.Name]
     ) extends morphir.ir.Type.Specification[A]{}
     
     final case class TypeAliasSpecification[A](
-      arg1: morphir.sdk.List.List[morphir.ir.Name.Name],
-      arg2: morphir.ir.Type.Type[A]
+      typeParams: morphir.sdk.List.List[morphir.ir.Name.Name],
+      typeExp: morphir.ir.Type.Type[A]
     ) extends morphir.ir.Type.Specification[A]{}
   
   }
@@ -91,40 +91,40 @@ object Type{
   object Type{
   
     final case class ExtensibleRecord[A](
-      arg1: A,
-      arg2: morphir.ir.Name.Name,
-      arg3: morphir.sdk.List.List[morphir.ir.Type.Field[A]]
+      attrs: A,
+      variableName: morphir.ir.Name.Name,
+      fieldTypes: morphir.sdk.List.List[morphir.ir.Type.Field[A]]
     ) extends morphir.ir.Type.Type[A]{}
     
     final case class Function[A](
-      arg1: A,
-      arg2: morphir.ir.Type.Type[A],
-      arg3: morphir.ir.Type.Type[A]
+      attrs: A,
+      argumentType: morphir.ir.Type.Type[A],
+      returnType: morphir.ir.Type.Type[A]
     ) extends morphir.ir.Type.Type[A]{}
     
     final case class Record[A](
-      arg1: A,
-      arg2: morphir.sdk.List.List[morphir.ir.Type.Field[A]]
+      attrs: A,
+      fieldTypes: morphir.sdk.List.List[morphir.ir.Type.Field[A]]
     ) extends morphir.ir.Type.Type[A]{}
     
     final case class Reference[A](
-      arg1: A,
-      arg2: morphir.ir.FQName.FQName,
-      arg3: morphir.sdk.List.List[morphir.ir.Type.Type[A]]
+      attrs: A,
+      typeName: morphir.ir.FQName.FQName,
+      typeParameters: morphir.sdk.List.List[morphir.ir.Type.Type[A]]
     ) extends morphir.ir.Type.Type[A]{}
     
     final case class Tuple[A](
-      arg1: A,
-      arg2: morphir.sdk.List.List[morphir.ir.Type.Type[A]]
+      attrs: A,
+      elementTypes: morphir.sdk.List.List[morphir.ir.Type.Type[A]]
     ) extends morphir.ir.Type.Type[A]{}
     
     final case class Unit[A](
-      arg1: A
+      attrs: A
     ) extends morphir.ir.Type.Type[A]{}
     
     final case class Variable[A](
-      arg1: A,
-      arg2: morphir.ir.Name.Name
+      attrs: A,
+      name: morphir.ir.Name.Name
     ) extends morphir.ir.Type.Type[A]{}
   
   }
@@ -272,6 +272,16 @@ object Type{
         ) : morphir.ir.Type.Specification[A])
     }
   
+  def derivedTypeSpecification[A](
+    typeParams: morphir.sdk.List.List[morphir.ir.Name.Name]
+  )(
+    details: morphir.ir.Type.DerivedTypeSpecificationDetails[A]
+  ): morphir.ir.Type.Specification[A] =
+    (morphir.ir.Type.DerivedTypeSpecification(
+      typeParams,
+      details
+    ) : morphir.ir.Type.Specification[A])
+  
   def eraseAttributes[A](
     typeDef: morphir.ir.Type.Definition[A]
   ): morphir.ir.Type.Definition[scala.Unit] =
@@ -314,27 +324,27 @@ object Type{
     }
   
   def extensibleRecord[A](
-    attributes: A
+    attrs: A
   )(
     variableName: morphir.ir.Name.Name
   )(
     fieldTypes: morphir.sdk.List.List[morphir.ir.Type.Field[A]]
   ): morphir.ir.Type.Type[A] =
     (morphir.ir.Type.ExtensibleRecord(
-      attributes,
+      attrs,
       variableName,
       fieldTypes
     ) : morphir.ir.Type.Type[A])
   
   def function[A](
-    attributes: A
+    attrs: A
   )(
     argumentType: morphir.ir.Type.Type[A]
   )(
     returnType: morphir.ir.Type.Type[A]
   ): morphir.ir.Type.Type[A] =
     (morphir.ir.Type.Function(
-      attributes,
+      attrs,
       argumentType,
       returnType
     ) : morphir.ir.Type.Type[A])
@@ -361,7 +371,7 @@ object Type{
             case (ctorName, ctorArgs) => 
               morphir.sdk.Result.map(morphir.sdk.Tuple.pair[Name.Name, ConstructorArgs[B]](ctorName))(morphir.sdk.ResultList.keepAllErrors(morphir.sdk.List.map(({
                 case (argName, argType) => 
-                  morphir.sdk.Result.map[E, Type[B], (Name.Name, Type[B])](morphir.sdk.Tuple.pair(argName))(f(argType))
+                  morphir.sdk.Result.map[E,Type[B], (Name.Name, Type[B])](morphir.sdk.Tuple.pair(argName))(f(argType))
               } : ((morphir.ir.Name.Name, morphir.ir.Type.Type[A])) => morphir.sdk.Result.Result[E, (morphir.ir.Name.Name, morphir.ir.Type.Type[B])]))(ctorArgs)))
           } : ((morphir.ir.Name.Name, morphir.sdk.List.List[(morphir.ir.Name.Name, morphir.ir.Type.Type[A])])) => morphir.sdk.Result.Result[morphir.sdk.List.List[E], (morphir.ir.Name.Name, morphir.sdk.List.List[(morphir.ir.Name.Name, morphir.ir.Type.Type[B])])]))(morphir.sdk.Dict.toList(constructors.value)))))
           
@@ -506,24 +516,24 @@ object Type{
     (morphir.ir.Type.OpaqueTypeSpecification(typeParams) : morphir.ir.Type.Specification[A])
   
   def record[A](
-    attributes: A
+    attrs: A
   )(
     fieldTypes: morphir.sdk.List.List[morphir.ir.Type.Field[A]]
   ): morphir.ir.Type.Type[A] =
     (morphir.ir.Type.Record(
-      attributes,
+      attrs,
       fieldTypes
     ) : morphir.ir.Type.Type[A])
   
   def reference[A](
-    attributes: A
+    attrs: A
   )(
     typeName: morphir.ir.FQName.FQName
   )(
     typeParameters: morphir.sdk.List.List[morphir.ir.Type.Type[A]]
   ): morphir.ir.Type.Type[A] =
     (morphir.ir.Type.Reference(
-      attributes,
+      attrs,
       typeName,
       typeParameters
     ) : morphir.ir.Type.Type[A])
@@ -534,7 +544,7 @@ object Type{
     original: morphir.ir.Type.Type[Ta]
   ): morphir.ir.Type.Type[Ta] =
     original match {
-      case morphir.ir.Type.Variable(_, varName) =>
+      case morphir.ir.Type.Variable(a, varName) => 
         morphir.sdk.Maybe.withDefault(original)(morphir.sdk.Dict.get(varName)(mapping))
       case morphir.ir.Type.Reference(a, fQName, typeArgs) => 
         (morphir.ir.Type.Reference(
@@ -590,12 +600,12 @@ object Type{
             morphir.ir.Name.toTitleCase(localName)
           ))
           
-          morphir.sdk.String.join(""" """)(morphir.sdk.List.cons(referenceName)(morphir.sdk.List.map(morphir.ir.Type._toString[A])(args)))
+          morphir.sdk.String.join(""" """)(morphir.sdk.List.cons(referenceName)(morphir.sdk.List.map(morphir.ir.Type._toString)(args)))
         }
       case morphir.ir.Type.Tuple(_, elems) => 
         morphir.sdk.String.concat(morphir.sdk.List(
           """( """,
-          morphir.sdk.String.join(""", """)(morphir.sdk.List.map(morphir.ir.Type._toString[A])(elems)),
+          morphir.sdk.String.join(""", """)(morphir.sdk.List.map(morphir.ir.Type._toString)(elems)),
           """ )"""
         ))
       case morphir.ir.Type.Record(_, fields) => 
@@ -640,12 +650,12 @@ object Type{
     }
   
   def tuple[A](
-    attributes: A
+    attrs: A
   )(
     elementTypes: morphir.sdk.List.List[morphir.ir.Type.Type[A]]
   ): morphir.ir.Type.Type[A] =
     (morphir.ir.Type.Tuple(
-      attributes,
+      attrs,
       elementTypes
     ) : morphir.ir.Type.Type[A])
   
@@ -690,17 +700,17 @@ object Type{
     }
   
   def unit[A](
-    attributes: A
+    attrs: A
   ): morphir.ir.Type.Type[A] =
-    (morphir.ir.Type.Unit(attributes) : morphir.ir.Type.Type[A])
+    (morphir.ir.Type.Unit(attrs) : morphir.ir.Type.Type[A])
   
   def variable[A](
-    attributes: A
+    attrs: A
   )(
     name: morphir.ir.Name.Name
   ): morphir.ir.Type.Type[A] =
     (morphir.ir.Type.Variable(
-      attributes,
+      attrs,
       name
     ) : morphir.ir.Type.Type[A])
 

--- a/morphir/ir/src/morphir/ir/Value.scala
+++ b/morphir/ir/src/morphir/ir/Value.scala
@@ -4,9 +4,6 @@ package morphir.ir
 */
 object Value{
 
-  implicit val nameOrdering: Ordering[Name.Name] =
-      (_: Name.Name, _: Name.Name) => 0
-
   final case class Definition[Ta, Va](
     inputTypes: morphir.sdk.List.List[(morphir.ir.Name.Name, Va, morphir.ir.Type.Type[Ta])],
     outputType: morphir.ir.Type.Type[Ta],
@@ -22,43 +19,43 @@ object Value{
   object Pattern{
 
     final case class AsPattern[A](
-      arg1: A,
-      arg2: morphir.ir.Value.Pattern[A],
-      arg3: morphir.ir.Name.Name
+      attrs: A,
+      pattern: morphir.ir.Value.Pattern[A],
+      name: morphir.ir.Name.Name
     ) extends morphir.ir.Value.Pattern[A]{}
 
     final case class ConstructorPattern[A](
-      arg1: A,
-      arg2: morphir.ir.FQName.FQName,
-      arg3: morphir.sdk.List.List[morphir.ir.Value.Pattern[A]]
+      attrs: A,
+      constructorName: morphir.ir.FQName.FQName,
+      argumentPatterns: morphir.sdk.List.List[morphir.ir.Value.Pattern[A]]
     ) extends morphir.ir.Value.Pattern[A]{}
 
     final case class EmptyListPattern[A](
-      arg1: A
+      attrs: A
     ) extends morphir.ir.Value.Pattern[A]{}
 
     final case class HeadTailPattern[A](
-      arg1: A,
-      arg2: morphir.ir.Value.Pattern[A],
-      arg3: morphir.ir.Value.Pattern[A]
+      attrs: A,
+      headPattern: morphir.ir.Value.Pattern[A],
+      tailPattern: morphir.ir.Value.Pattern[A]
     ) extends morphir.ir.Value.Pattern[A]{}
 
     final case class LiteralPattern[A](
-      arg1: A,
-      arg2: morphir.ir.Literal.Literal
+      attrs: A,
+      value: morphir.ir.Literal.Literal
     ) extends morphir.ir.Value.Pattern[A]{}
 
     final case class TuplePattern[A](
-      arg1: A,
-      arg2: morphir.sdk.List.List[morphir.ir.Value.Pattern[A]]
+      attrs: A,
+      elementPatterns: morphir.sdk.List.List[morphir.ir.Value.Pattern[A]]
     ) extends morphir.ir.Value.Pattern[A]{}
 
     final case class UnitPattern[A](
-      arg1: A
+      attrs: A
     ) extends morphir.ir.Value.Pattern[A]{}
 
     final case class WildcardPattern[A](
-      arg1: A
+      attrs: A
     ) extends morphir.ir.Value.Pattern[A]{}
 
   }
@@ -97,104 +94,104 @@ object Value{
   object Value{
 
     final case class Apply[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Value.Value[Ta, Va],
-      arg3: morphir.ir.Value.Value[Ta, Va]
+      attrs: Va,
+      func: morphir.ir.Value.Value[Ta, Va],
+      argument: morphir.ir.Value.Value[Ta, Va]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Constructor[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.FQName.FQName
+      attrs: Va,
+      fullyQualifiedName: morphir.ir.FQName.FQName
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Destructure[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Value.Pattern[Va],
-      arg3: morphir.ir.Value.Value[Ta, Va],
-      arg4: morphir.ir.Value.Value[Ta, Va]
+      attrs: Va,
+      pattern: morphir.ir.Value.Pattern[Va],
+      valueToDestruct: morphir.ir.Value.Value[Ta, Va],
+      inValue: morphir.ir.Value.Value[Ta, Va]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Field[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Value.Value[Ta, Va],
-      arg3: morphir.ir.Name.Name
+      attrs: Va,
+      subjectValue: morphir.ir.Value.Value[Ta, Va],
+      fieldName: morphir.ir.Name.Name
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class FieldFunction[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Name.Name
+      attrs: Va,
+      fieldName: morphir.ir.Name.Name
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class IfThenElse[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Value.Value[Ta, Va],
-      arg3: morphir.ir.Value.Value[Ta, Va],
-      arg4: morphir.ir.Value.Value[Ta, Va]
+      attrs: Va,
+      condition: morphir.ir.Value.Value[Ta, Va],
+      thenBranch: morphir.ir.Value.Value[Ta, Va],
+      elseBranch: morphir.ir.Value.Value[Ta, Va]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Lambda[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Value.Pattern[Va],
-      arg3: morphir.ir.Value.Value[Ta, Va]
+      attrs: Va,
+      argumentPattern: morphir.ir.Value.Pattern[Va],
+      body: morphir.ir.Value.Value[Ta, Va]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class LetDefinition[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Name.Name,
-      arg3: morphir.ir.Value.Definition[Ta, Va],
-      arg4: morphir.ir.Value.Value[Ta, Va]
+      attrs: Va,
+      valueName: morphir.ir.Name.Name,
+      valueDefinition: morphir.ir.Value.Definition[Ta, Va],
+      inValue: morphir.ir.Value.Value[Ta, Va]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class LetRecursion[Ta, Va](
-      arg1: Va,
-      arg2: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Definition[Ta, Va]],
-      arg3: morphir.ir.Value.Value[Ta, Va]
+      attrs: Va,
+      valueDefinitions: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Definition[Ta, Va]],
+      inValue: morphir.ir.Value.Value[Ta, Va]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class List[Ta, Va](
-      arg1: Va,
-      arg2: morphir.sdk.List.List[morphir.ir.Value.Value[Ta, Va]]
+      attrs: Va,
+      items: morphir.sdk.List.List[morphir.ir.Value.Value[Ta, Va]]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Literal[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Literal.Literal
+      attrs: Va,
+      value: morphir.ir.Literal.Literal
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class PatternMatch[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Value.Value[Ta, Va],
-      arg3: morphir.sdk.List.List[(morphir.ir.Value.Pattern[Va], morphir.ir.Value.Value[Ta, Va])]
+      attrs: Va,
+      branchOutOn: morphir.ir.Value.Value[Ta, Va],
+      cases: morphir.sdk.List.List[(morphir.ir.Value.Pattern[Va], morphir.ir.Value.Value[Ta, Va])]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Record[Ta, Va](
-      arg1: Va,
-      arg2: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Value[Ta, Va]]
+      attrs: Va,
+      fields: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Value[Ta, Va]]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Reference[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.FQName.FQName
+      attrs: Va,
+      fullyQualifiedName: morphir.ir.FQName.FQName
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Tuple[Ta, Va](
-      arg1: Va,
-      arg2: morphir.sdk.List.List[morphir.ir.Value.Value[Ta, Va]]
+      attrs: Va,
+      elements: morphir.sdk.List.List[morphir.ir.Value.Value[Ta, Va]]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Unit[Ta, Va](
-      arg1: Va
+      attrs: Va
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class UpdateRecord[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Value.Value[Ta, Va],
-      arg3: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Value[Ta, Va]]
+      attrs: Va,
+      valueToUpdate: morphir.ir.Value.Value[Ta, Va],
+      fieldsToUpdate: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Value[Ta, Va]]
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
     final case class Variable[Ta, Va](
-      arg1: Va,
-      arg2: morphir.ir.Name.Name
+      attrs: Va,
+      name: morphir.ir.Name.Name
     ) extends morphir.ir.Value.Value[Ta, Va]{}
 
   }
@@ -236,27 +233,27 @@ object Value{
   val Variable: morphir.ir.Value.Value.Variable.type  = morphir.ir.Value.Value.Variable
 
   def apply[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
-    function: morphir.ir.Value.Value[Ta, Va]
+    func: morphir.ir.Value.Value[Ta, Va]
   )(
     argument: morphir.ir.Value.Value[Ta, Va]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Apply(
-      attributes,
-      function,
+      attrs,
+      func,
       argument
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def asPattern[A](
-    attributes: A
+    attrs: A
   )(
     pattern: morphir.ir.Value.Pattern[A]
   )(
     name: morphir.ir.Name.Name
   ): morphir.ir.Value.Pattern[A] =
     (morphir.ir.Value.AsPattern(
-      attributes,
+      attrs,
       pattern,
       name
     ) : morphir.ir.Value.Pattern[A])
@@ -278,9 +275,9 @@ object Value{
       case morphir.ir.Value.AsPattern(a, p2, _) =>
         morphir.sdk.List.cons(a)(morphir.ir.Value.collectPatternAttributes(p2))
       case morphir.ir.Value.TuplePattern(a, elementPatterns) =>
-        morphir.sdk.List.cons(a)(morphir.sdk.List.concatMap(morphir.ir.Value.collectPatternAttributes[A])(elementPatterns))
+        morphir.sdk.List.cons(a)(morphir.sdk.List.concatMap(morphir.ir.Value.collectPatternAttributes)(elementPatterns))
       case morphir.ir.Value.ConstructorPattern(a, _, argumentPatterns) =>
-        morphir.sdk.List.cons(a)(morphir.sdk.List.concatMap(morphir.ir.Value.collectPatternAttributes[A])(argumentPatterns))
+        morphir.sdk.List.cons(a)(morphir.sdk.List.concatMap(morphir.ir.Value.collectPatternAttributes)(argumentPatterns))
       case morphir.ir.Value.EmptyListPattern(a) =>
         morphir.sdk.List(a)
       case morphir.ir.Value.HeadTailPattern(a, headPattern, tailPattern) =>
@@ -303,9 +300,9 @@ object Value{
       case morphir.ir.Value.AsPattern(_, subject, _) =>
         morphir.ir.Value.collectPatternReferences(subject)
       case morphir.ir.Value.TuplePattern(_, elemPatterns) =>
-        morphir.sdk.List.foldl(morphir.sdk.Set.union[FQName.FQName])(morphir.sdk.Set.empty)(morphir.sdk.List.map(morphir.ir.Value.collectPatternReferences[Va])(elemPatterns))
+        morphir.sdk.List.foldl(morphir.sdk.Set.union)(morphir.sdk.Set.empty)(morphir.sdk.List.map(morphir.ir.Value.collectPatternReferences)(elemPatterns))
       case morphir.ir.Value.ConstructorPattern(_, fQName, argPatterns) =>
-        morphir.sdk.Set.insert(fQName)(morphir.sdk.List.foldl(morphir.sdk.Set.union[FQName.FQName])(morphir.sdk.Set.empty)(morphir.sdk.List.map(morphir.ir.Value.collectPatternReferences[Va])(argPatterns)))
+        morphir.sdk.Set.insert(fQName)(morphir.sdk.List.foldl(morphir.sdk.Set.union)(morphir.sdk.Set.empty)(morphir.sdk.List.map(morphir.ir.Value.collectPatternReferences)(argPatterns)))
       case morphir.ir.Value.EmptyListPattern(_) =>
         morphir.sdk.Set.empty
       case morphir.ir.Value.HeadTailPattern(_, headPattern, tailPattern) =>
@@ -465,7 +462,7 @@ object Value{
     def collectUnion(
       values: morphir.sdk.List.List[morphir.ir.Value.Value[Ta, Va]]
     ): morphir.sdk.Set.Set[morphir.ir.Name.Name] =
-      morphir.sdk.List.foldl(morphir.sdk.Set.union[Name.Name])(morphir.sdk.Set.empty)(morphir.sdk.List.map(morphir.ir.Value.collectVariables[Ta, Va])(values))
+      morphir.sdk.List.foldl(morphir.sdk.Set.union)(morphir.sdk.Set.empty)(morphir.sdk.List.map(morphir.ir.Value.collectVariables)(values))
 
     value match {
       case morphir.ir.Value.Tuple(_, elements) =>
@@ -491,7 +488,7 @@ object Value{
           inValue
         )))
       case morphir.ir.Value.LetRecursion(_, valueDefinitions, inValue) =>
-        morphir.sdk.List.foldl(morphir.sdk.Set.union[Name.Name])(morphir.sdk.Set.empty)(morphir.sdk.List.append(morphir.sdk.List(morphir.ir.Value.collectVariables(inValue)))(morphir.sdk.List.map(({
+        morphir.sdk.List.foldl(morphir.sdk.Set.union)(morphir.sdk.Set.empty)(morphir.sdk.List.append(morphir.sdk.List(morphir.ir.Value.collectVariables(inValue)))(morphir.sdk.List.map(({
           case (defName, _def) =>
             morphir.sdk.Set.insert(defName)(morphir.ir.Value.collectVariables(_def.body))
         } : ((morphir.ir.Name.Name, morphir.ir.Value.Definition[Ta, Va])) => morphir.sdk.Set.Set[morphir.ir.Name.Name]))(morphir.sdk.Dict.toList(valueDefinitions))))
@@ -507,7 +504,7 @@ object Value{
           elseBranch
         ))
       case morphir.ir.Value.PatternMatch(_, branchOutOn, cases) =>
-        morphir.sdk.Set.union(morphir.ir.Value.collectVariables(branchOutOn))(collectUnion(morphir.sdk.List.map(morphir.sdk.Tuple.second[Pattern[Va], Value[Ta, Va]])(cases)))
+        morphir.sdk.Set.union(morphir.ir.Value.collectVariables(branchOutOn))(collectUnion(morphir.sdk.List.map(morphir.sdk.Tuple.second)(cases)))
       case morphir.ir.Value.UpdateRecord(_, valueToUpdate, fieldsToUpdate) =>
         morphir.sdk.Set.union(morphir.ir.Value.collectVariables(valueToUpdate))(collectUnion(morphir.sdk.Dict.values(fieldsToUpdate)))
       case _ =>
@@ -516,24 +513,24 @@ object Value{
   }
 
   def constructor[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     fullyQualifiedName: morphir.ir.FQName.FQName
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Constructor(
-      attributes,
+      attrs,
       fullyQualifiedName
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def constructorPattern[A](
-    attributes: A
+    attrs: A
   )(
     constructorName: morphir.ir.FQName.FQName
   )(
     argumentPatterns: morphir.sdk.List.List[morphir.ir.Value.Pattern[A]]
   ): morphir.ir.Value.Pattern[A] =
     (morphir.ir.Value.ConstructorPattern(
-      attributes,
+      attrs,
       constructorName,
       argumentPatterns
     ) : morphir.ir.Value.Pattern[A])
@@ -560,7 +557,7 @@ object Value{
     _def.inputTypes match {
       case Nil =>
         _def.body
-      case (firstArgName, va, _) :: restOfArgs =>
+      case ((firstArgName, va, _) :: restOfArgs) =>
         (morphir.ir.Value.Lambda(
           va,
           (morphir.ir.Value.AsPattern(
@@ -572,31 +569,47 @@ object Value{
         ) : morphir.ir.Value.Value[Ta, Va])
     }
 
+  def destructure[Ta, Va](
+    attrs: Va
+  )(
+    pattern: morphir.ir.Value.Pattern[Va]
+  )(
+    valueToDestruct: morphir.ir.Value.Value[Ta, Va]
+  )(
+    inValue: morphir.ir.Value.Value[Ta, Va]
+  ): morphir.ir.Value.Value[Ta, Va] =
+    (morphir.ir.Value.Destructure(
+      attrs,
+      pattern,
+      valueToDestruct,
+      inValue
+    ) : morphir.ir.Value.Value[Ta, Va])
+
   def emptyListPattern[A](
-    attributes: A
+    attrs: A
   ): morphir.ir.Value.Pattern[A] =
-    (morphir.ir.Value.EmptyListPattern(attributes) : morphir.ir.Value.Pattern[A])
+    (morphir.ir.Value.EmptyListPattern(attrs) : morphir.ir.Value.Pattern[A])
 
   def field[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     subjectValue: morphir.ir.Value.Value[Ta, Va]
   )(
     fieldName: morphir.ir.Name.Name
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Field(
-      attributes,
+      attrs,
       subjectValue,
       fieldName
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def fieldFunction[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     fieldName: morphir.ir.Name.Name
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.FieldFunction(
-      attributes,
+      attrs,
       fieldName
     ) : morphir.ir.Value.Value[Ta, Va])
 
@@ -617,20 +630,20 @@ object Value{
   }
 
   def headTailPattern[A](
-    attributes: A
+    attrs: A
   )(
     headPattern: morphir.ir.Value.Pattern[A]
   )(
     tailPattern: morphir.ir.Value.Pattern[A]
   ): morphir.ir.Value.Pattern[A] =
     (morphir.ir.Value.HeadTailPattern(
-      attributes,
+      attrs,
       headPattern,
       tailPattern
     ) : morphir.ir.Value.Pattern[A])
 
   def ifThenElse[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     condition: morphir.ir.Value.Value[Ta, Va]
   )(
@@ -639,7 +652,7 @@ object Value{
     elseBranch: morphir.ir.Value.Value[Ta, Va]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.IfThenElse(
-      attributes,
+      attrs,
       condition,
       thenBranch,
       elseBranch
@@ -1022,20 +1035,20 @@ object Value{
     }
 
   def lambda[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     argumentPattern: morphir.ir.Value.Pattern[Va]
   )(
     body: morphir.ir.Value.Value[Ta, Va]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Lambda(
-      attributes,
+      attrs,
       argumentPattern,
       body
     ) : morphir.ir.Value.Value[Ta, Va])
 
-  def letDef[Ta, Va](
-    attributes: Va
+  def letDefinition[Ta, Va](
+    attrs: Va
   )(
     valueName: morphir.ir.Name.Name
   )(
@@ -1044,14 +1057,14 @@ object Value{
     inValue: morphir.ir.Value.Value[Ta, Va]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.LetDefinition(
-      attributes,
+      attrs,
       valueName,
       valueDefinition,
       inValue
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def letDestruct[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     pattern: morphir.ir.Value.Pattern[Va]
   )(
@@ -1060,52 +1073,52 @@ object Value{
     inValue: morphir.ir.Value.Value[Ta, Va]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Destructure(
-      attributes,
+      attrs,
       pattern,
       valueToDestruct,
       inValue
     ) : morphir.ir.Value.Value[Ta, Va])
 
-  def letRec[Ta, Va](
-    attributes: Va
+  def letRecursion[Ta, Va](
+    attrs: Va
   )(
     valueDefinitions: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Definition[Ta, Va]]
   )(
     inValue: morphir.ir.Value.Value[Ta, Va]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.LetRecursion(
-      attributes,
+      attrs,
       valueDefinitions,
       inValue
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def list[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     items: morphir.sdk.List.List[morphir.ir.Value.Value[Ta, Va]]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.List(
-      attributes,
+      attrs,
       items
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def literal[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     value: morphir.ir.Literal.Literal
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Literal(
-      attributes,
+      attrs,
       value
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def literalPattern[A](
-    attributes: A
+    attrs: A
   )(
     value: morphir.ir.Literal.Literal
   ): morphir.ir.Value.Pattern[A] =
     (morphir.ir.Value.LiteralPattern(
-      attributes,
+      attrs,
       value
     ) : morphir.ir.Value.Pattern[A])
 
@@ -1116,12 +1129,14 @@ object Value{
   )(
     _def: morphir.ir.Value.Definition[Ta, Va]
   ): morphir.sdk.Result.Result[morphir.sdk.List.List[E], morphir.ir.Value.Definition[Ta, Va]] =
-    morphir.sdk.Result.map3(((inputTypes: morphir.sdk.List.List[(morphir.ir.Name.Name, Va, morphir.ir.Type.Type[Ta])], outputType: morphir.ir.Type.Type[Ta], body: morphir.ir.Value.Value[Ta, Va]) =>
-      (morphir.ir.Value.Definition(
-        inputTypes,
-        outputType,
-        body
-      ): morphir.ir.Value.Definition[Ta, Va])))(morphir.sdk.ResultList.keepAllErrors(morphir.sdk.List.map(({
+    morphir.sdk.Result.map3(((inputTypes: morphir.sdk.List.List[(morphir.ir.Name.Name, Va, morphir.ir.Type.Type[Ta])]) =>
+      ((outputType: morphir.ir.Type.Type[Ta]) =>
+        ((body: morphir.ir.Value.Value[Ta, Va]) =>
+          (morphir.ir.Value.Definition(
+            inputTypes,
+            outputType,
+            body
+          ) : morphir.ir.Value.Definition[Ta, Va])))))(morphir.sdk.ResultList.keepAllErrors(morphir.sdk.List.map(({
       case (name, attr, tpe) =>
         morphir.sdk.Result.map(((t: morphir.ir.Type.Type[Ta]) =>
           (name, attr, t)))(mapType(tpe))
@@ -1345,25 +1360,25 @@ object Value{
     }
 
   def patternMatch[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     branchOutOn: morphir.ir.Value.Value[Ta, Va]
   )(
     cases: morphir.sdk.List.List[(morphir.ir.Value.Pattern[Va], morphir.ir.Value.Value[Ta, Va])]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.PatternMatch(
-      attributes,
+      attrs,
       branchOutOn,
       cases
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def record[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     fields: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Value[Ta, Va]]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Record(
-      attributes,
+      attrs,
       fields
     ) : morphir.ir.Value.Value[Ta, Va])
 
@@ -1404,7 +1419,7 @@ object Value{
           morphir.ir.Value.reduceValueBottomUp(mapNode)(elseBranch)
         ))
       case morphir.ir.Value.PatternMatch(_, branchOutOn, cases) =>
-        mapNode(currentValue)(morphir.sdk.List.append(morphir.sdk.List(morphir.ir.Value.reduceValueBottomUp(mapNode)(branchOutOn)))(morphir.sdk.List.map(morphir.ir.Value.reduceValueBottomUp(mapNode))(morphir.sdk.List.map(morphir.sdk.Tuple.second[Pattern[ValueAttribute], Value[TypeAttribute, ValueAttribute]])(cases))))
+        mapNode(currentValue)(morphir.sdk.List.append(morphir.sdk.List(morphir.ir.Value.reduceValueBottomUp(mapNode)(branchOutOn)))(morphir.sdk.List.map(morphir.ir.Value.reduceValueBottomUp(mapNode))(morphir.sdk.List.map(morphir.sdk.Tuple.second)(cases))))
       case morphir.ir.Value.UpdateRecord(_, valueToUpdate, fieldsToUpdate) =>
         mapNode(currentValue)(morphir.sdk.List.append(morphir.sdk.List(morphir.ir.Value.reduceValueBottomUp(mapNode)(valueToUpdate)))(morphir.sdk.List.map(morphir.ir.Value.reduceValueBottomUp(mapNode))(morphir.sdk.Dict.values(fieldsToUpdate))))
       case _ =>
@@ -1414,12 +1429,12 @@ object Value{
     }
 
   def reference[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     fullyQualifiedName: morphir.ir.FQName.FQName
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Reference(
-      attributes,
+      attrs,
       fullyQualifiedName
     ) : morphir.ir.Value.Value[Ta, Va])
 
@@ -1441,7 +1456,7 @@ object Value{
   ): morphir.ir.Value.Value[Ta, Va] =
     morphir.ir.Value.rewriteValue(((_val: morphir.ir.Value.Value[Ta, Va]) =>
       _val match {
-        case morphir.ir.Value.Apply(tpe, morphir.ir.Value.Apply(_, morphir.ir.Value.Reference(_, ((("""morphir""" :: Nil) :: ("""s""" :: """d""" :: """k""" :: Nil) :: Nil),(("""maybe""" :: Nil) :: Nil), ("""with""" :: """default""" :: Nil))), defaultValue), morphir.ir.Value.Apply(maybetpe, morphir.ir.Value.Apply(_, morphir.ir.Value.Reference(_, ((("""morphir""" :: Nil) :: ("""s""" :: """d""" :: """k""" :: Nil) :: Nil), (("""maybe""" :: Nil) :: Nil), ("""map""" :: Nil))), mapLambda), inputMaybe)) =>
+        case morphir.ir.Value.Apply(tpe, morphir.ir.Value.Apply(_, morphir.ir.Value.Reference(_, ((("""morphir""" :: Nil) :: (("""s""" :: ("""d""" :: ("""k""" :: Nil))) :: Nil)), (("""maybe""" :: Nil) :: Nil), ("""with""" :: ("""default""" :: Nil)))), defaultValue), morphir.ir.Value.Apply(maybetpe, morphir.ir.Value.Apply(_, morphir.ir.Value.Reference(_, ((("""morphir""" :: Nil) :: (("""s""" :: ("""d""" :: ("""k""" :: Nil))) :: Nil)), (("""maybe""" :: Nil) :: Nil), ("""map""" :: Nil))), mapLambda), inputMaybe)) =>
           mapLambda match {
             case morphir.ir.Value.Lambda(_, argPattern, bodyValue) =>
               (morphir.sdk.Maybe.Just((morphir.ir.Value.PatternMatch(
@@ -1478,7 +1493,7 @@ object Value{
               ) : morphir.ir.Value.Value[Ta, Va])) : morphir.sdk.Maybe.Maybe[morphir.ir.Value.Value[Ta, Va]])
             case _ =>
               {
-                val argName: Name.Name = morphir.ir.Value.generateUniqueName(mapLambda)
+                val argName: T2 = morphir.ir.Value.generateUniqueName(mapLambda)
 
                 (morphir.sdk.Maybe.Just((morphir.ir.Value.PatternMatch(
                   tpe,
@@ -1730,13 +1745,13 @@ object Value{
             case morphir.ir.Value.Tuple(_, elems) =>
               morphir.sdk.String.concat(morphir.sdk.List(
                 """( """,
-                morphir.sdk.String.join(""", """)(morphir.sdk.List.map(morphir.ir.Value._toString[Ta, Va])(elems)),
+                morphir.sdk.String.join(""", """)(morphir.sdk.List.map(morphir.ir.Value._toString)(elems)),
                 """ )"""
               ))
             case morphir.ir.Value.List(_, items) =>
               morphir.sdk.String.concat(morphir.sdk.List(
                 """[ """,
-                morphir.sdk.String.join(""", """)(morphir.sdk.List.map(morphir.ir.Value._toString[Ta, Va])(items)),
+                morphir.sdk.String.join(""", """)(morphir.sdk.List.map(morphir.ir.Value._toString)(items)),
                 """ ]"""
               ))
             case morphir.ir.Value.Record(_, fields) =>
@@ -1884,22 +1899,22 @@ object Value{
   }
 
   def tuple[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     elements: morphir.sdk.List.List[morphir.ir.Value.Value[Ta, Va]]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Tuple(
-      attributes,
+      attrs,
       elements
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def tuplePattern[A](
-    attributes: A
+    attrs: A
   )(
     elementPatterns: morphir.sdk.List.List[morphir.ir.Value.Pattern[A]]
   ): morphir.ir.Value.Pattern[A] =
     (morphir.ir.Value.TuplePattern(
-      attributes,
+      attrs,
       elementPatterns
     ) : morphir.ir.Value.Pattern[A])
 
@@ -1918,7 +1933,6 @@ object Value{
       (body, bodyType) match {
         case (morphir.ir.Value.Lambda(va, morphir.ir.Value.AsPattern(_, morphir.ir.Value.WildcardPattern(_), argName), lambdaBody), morphir.ir.Type.Function(_, argType, returnType)) =>
           liftLambdaArguments(morphir.sdk.List.append(args)(morphir.sdk.List((argName, va, argType))))(returnType)(lambdaBody)
-          // TODO Morphir was unable to resolve ^ this `append` to List.append but rather resolved to Basics.append, why?
         case _ =>
           morphir.ir.Value.Definition(
             body = body,
@@ -1949,19 +1963,24 @@ object Value{
     }
 
   def unit[Ta, Va](
-    attributes: Va
+    attrs: Va
   ): morphir.ir.Value.Value[Ta, Va] =
-    (morphir.ir.Value.Unit(attributes) : morphir.ir.Value.Value[Ta, Va])
+    (morphir.ir.Value.Unit(attrs) : morphir.ir.Value.Value[Ta, Va])
 
-  def update[Ta, Va](
-    attributes: Va
+  def unitPattern[A](
+    attrs: A
+  ): morphir.ir.Value.Pattern[A] =
+    (morphir.ir.Value.UnitPattern(attrs) : morphir.ir.Value.Pattern[A])
+
+  def updateRecord[Ta, Va](
+    attrs: Va
   )(
     valueToUpdate: morphir.ir.Value.Value[Ta, Va]
   )(
     fieldsToUpdate: morphir.sdk.Dict.Dict[morphir.ir.Name.Name, morphir.ir.Value.Value[Ta, Va]]
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.UpdateRecord(
-      attributes,
+      attrs,
       valueToUpdate,
       fieldsToUpdate
     ) : morphir.ir.Value.Value[Ta, Va])
@@ -2009,18 +2028,18 @@ object Value{
     }
 
   def variable[Ta, Va](
-    attributes: Va
+    attrs: Va
   )(
     name: morphir.ir.Name.Name
   ): morphir.ir.Value.Value[Ta, Va] =
     (morphir.ir.Value.Variable(
-      attributes,
+      attrs,
       name
     ) : morphir.ir.Value.Value[Ta, Va])
 
   def wildcardPattern[A](
-    attributes: A
+    attrs: A
   ): morphir.ir.Value.Pattern[A] =
-    (morphir.ir.Value.WildcardPattern(attributes) : morphir.ir.Value.Pattern[A])
+    (morphir.ir.Value.WildcardPattern(attrs) : morphir.ir.Value.Pattern[A])
 
 }

--- a/morphir/ir/src/morphir/ir/_type/Codec.scala
+++ b/morphir/ir/src/morphir/ir/_type/Codec.scala
@@ -35,17 +35,17 @@ object Codec{
   ): io.circe.Encoder[morphir.ir.Type.Definition[A]] =
     ((definition: morphir.ir.Type.Definition[A]) =>
       definition match {
-        case morphir.ir.Type.CustomTypeDefinition(arg1, arg2) => 
+        case morphir.ir.Type.CustomTypeDefinition(typeParams, ctors) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""CustomTypeDefinition"""),
-            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(arg1),
-            morphir.ir.accesscontrolled.Codec.encodeAccessControlled(morphir.ir._type.Codec.encodeConstructors(encodeA))(arg2)
+            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(typeParams),
+            morphir.ir.accesscontrolled.Codec.encodeAccessControlled(morphir.ir._type.Codec.encodeConstructors(encodeA))(ctors)
           )
-        case morphir.ir.Type.TypeAliasDefinition(arg1, arg2) => 
+        case morphir.ir.Type.TypeAliasDefinition(typeParams, typeExp) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""TypeAliasDefinition"""),
-            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(arg1),
-            morphir.ir._type.Codec.encodeType(encodeA)(arg2)
+            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(typeParams),
+            morphir.ir._type.Codec.encodeType(encodeA)(typeExp)
           )
       })
   
@@ -73,28 +73,28 @@ object Codec{
   ): io.circe.Encoder[morphir.ir.Type.Specification[A]] =
     ((specification: morphir.ir.Type.Specification[A]) =>
       specification match {
-        case morphir.ir.Type.CustomTypeSpecification(arg1, arg2) => 
+        case morphir.ir.Type.CustomTypeSpecification(typeParams, ctors) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""CustomTypeSpecification"""),
-            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(arg1),
-            morphir.ir._type.Codec.encodeConstructors(encodeA)(arg2)
+            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(typeParams),
+            morphir.ir._type.Codec.encodeConstructors(encodeA)(ctors)
           )
-        case morphir.ir.Type.DerivedTypeSpecification(arg1, arg2) => 
+        case morphir.ir.Type.DerivedTypeSpecification(typeParams, details) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""DerivedTypeSpecification"""),
-            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(arg1),
-            morphir.ir._type.Codec.encodeDerivedTypeSpecificationDetails(encodeA)(arg2)
+            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(typeParams),
+            morphir.ir._type.Codec.encodeDerivedTypeSpecificationDetails(encodeA)(details)
           )
-        case morphir.ir.Type.OpaqueTypeSpecification(arg1) => 
+        case morphir.ir.Type.OpaqueTypeSpecification(typeParams) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""OpaqueTypeSpecification"""),
-            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(arg1)
+            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(typeParams)
           )
-        case morphir.ir.Type.TypeAliasSpecification(arg1, arg2) => 
+        case morphir.ir.Type.TypeAliasSpecification(typeParams, typeExp) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""TypeAliasSpecification"""),
-            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(arg1),
-            morphir.ir._type.Codec.encodeType(encodeA)(arg2)
+            morphir.sdk.list.Codec.encodeList(morphir.ir.name.Codec.encodeName)(typeParams),
+            morphir.ir._type.Codec.encodeType(encodeA)(typeExp)
           )
       })
   
@@ -103,49 +103,49 @@ object Codec{
   ): io.circe.Encoder[morphir.ir.Type.Type[A]] =
     ((_type: morphir.ir.Type.Type[A]) =>
       _type match {
-        case morphir.ir.Type.ExtensibleRecord(arg1, arg2, arg3) => 
+        case morphir.ir.Type.ExtensibleRecord(attrs, variableName, fieldTypes) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""ExtensibleRecord"""),
-            encodeA(arg1),
-            morphir.ir.name.Codec.encodeName(arg2),
-            morphir.sdk.list.Codec.encodeList(morphir.ir._type.Codec.encodeField(encodeA))(arg3)
+            encodeA(attrs),
+            morphir.ir.name.Codec.encodeName(variableName),
+            morphir.sdk.list.Codec.encodeList(morphir.ir._type.Codec.encodeField(encodeA))(fieldTypes)
           )
-        case morphir.ir.Type.Function(arg1, arg2, arg3) => 
+        case morphir.ir.Type.Function(attrs, argumentType, returnType) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Function"""),
-            encodeA(arg1),
-            morphir.ir._type.Codec.encodeType(encodeA)(arg2),
-            morphir.ir._type.Codec.encodeType(encodeA)(arg3)
+            encodeA(attrs),
+            morphir.ir._type.Codec.encodeType(encodeA)(argumentType),
+            morphir.ir._type.Codec.encodeType(encodeA)(returnType)
           )
-        case morphir.ir.Type.Record(arg1, arg2) => 
+        case morphir.ir.Type.Record(attrs, fieldTypes) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Record"""),
-            encodeA(arg1),
-            morphir.sdk.list.Codec.encodeList(morphir.ir._type.Codec.encodeField(encodeA))(arg2)
+            encodeA(attrs),
+            morphir.sdk.list.Codec.encodeList(morphir.ir._type.Codec.encodeField(encodeA))(fieldTypes)
           )
-        case morphir.ir.Type.Reference(arg1, arg2, arg3) => 
+        case morphir.ir.Type.Reference(attrs, typeName, typeParameters) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Reference"""),
-            encodeA(arg1),
-            morphir.ir.fqname.Codec.encodeFQName(arg2),
-            morphir.sdk.list.Codec.encodeList(morphir.ir._type.Codec.encodeType(encodeA))(arg3)
+            encodeA(attrs),
+            morphir.ir.fqname.Codec.encodeFQName(typeName),
+            morphir.sdk.list.Codec.encodeList(morphir.ir._type.Codec.encodeType(encodeA))(typeParameters)
           )
-        case morphir.ir.Type.Tuple(arg1, arg2) => 
+        case morphir.ir.Type.Tuple(attrs, elementTypes) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Tuple"""),
-            encodeA(arg1),
-            morphir.sdk.list.Codec.encodeList(morphir.ir._type.Codec.encodeType(encodeA))(arg2)
+            encodeA(attrs),
+            morphir.sdk.list.Codec.encodeList(morphir.ir._type.Codec.encodeType(encodeA))(elementTypes)
           )
-        case morphir.ir.Type.Unit(arg1) => 
+        case morphir.ir.Type.Unit(attrs) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Unit"""),
-            encodeA(arg1)
+            encodeA(attrs)
           )
-        case morphir.ir.Type.Variable(arg1, arg2) => 
+        case morphir.ir.Type.Variable(attrs, name) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Variable"""),
-            encodeA(arg1),
-            morphir.ir.name.Codec.encodeName(arg2)
+            encodeA(attrs),
+            morphir.ir.name.Codec.encodeName(name)
           )
       })
   
@@ -184,19 +184,19 @@ object Codec{
         tag match {
           case """CustomTypeDefinition""" => 
             for {
-              arg1 <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
-              arg2 <- c.downN(2).as(morphir.ir.accesscontrolled.Codec.decodeAccessControlled(morphir.ir._type.Codec.decodeConstructors(decodeA)))
+              typeParams <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
+              ctors <- c.downN(2).as(morphir.ir.accesscontrolled.Codec.decodeAccessControlled(morphir.ir._type.Codec.decodeConstructors(decodeA)))
             }  yield morphir.ir.Type.CustomTypeDefinition(
-              arg1,
-              arg2
+              typeParams,
+              ctors
             )
           case """TypeAliasDefinition""" => 
             for {
-              arg1 <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
-              arg2 <- c.downN(2).as(morphir.ir._type.Codec.decodeType(decodeA))
+              typeParams <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
+              typeExp <- c.downN(2).as(morphir.ir._type.Codec.decodeType(decodeA))
             }  yield morphir.ir.Type.TypeAliasDefinition(
-              arg1,
-              arg2
+              typeParams,
+              typeExp
             )
         })))
   
@@ -235,31 +235,31 @@ object Codec{
         tag match {
           case """CustomTypeSpecification""" => 
             for {
-              arg1 <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
-              arg2 <- c.downN(2).as(morphir.ir._type.Codec.decodeConstructors(decodeA))
+              typeParams <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
+              ctors <- c.downN(2).as(morphir.ir._type.Codec.decodeConstructors(decodeA))
             }  yield morphir.ir.Type.CustomTypeSpecification(
-              arg1,
-              arg2
+              typeParams,
+              ctors
             )
           case """DerivedTypeSpecification""" => 
             for {
-              arg1 <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
-              arg2 <- c.downN(2).as(morphir.ir._type.Codec.decodeDerivedTypeSpecificationDetails(decodeA))
+              typeParams <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
+              details <- c.downN(2).as(morphir.ir._type.Codec.decodeDerivedTypeSpecificationDetails(decodeA))
             }  yield morphir.ir.Type.DerivedTypeSpecification(
-              arg1,
-              arg2
+              typeParams,
+              details
             )
           case """OpaqueTypeSpecification""" => 
             for {
-              arg1 <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
-            }  yield morphir.ir.Type.OpaqueTypeSpecification(arg1)
+              typeParams <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
+            }  yield morphir.ir.Type.OpaqueTypeSpecification(typeParams)
           case """TypeAliasSpecification""" => 
             for {
-              arg1 <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
-              arg2 <- c.downN(2).as(morphir.ir._type.Codec.decodeType(decodeA))
+              typeParams <- c.downN(1).as(morphir.sdk.list.Codec.decodeList(morphir.ir.name.Codec.decodeName))
+              typeExp <- c.downN(2).as(morphir.ir._type.Codec.decodeType(decodeA))
             }  yield morphir.ir.Type.TypeAliasSpecification(
-              arg1,
-              arg2
+              typeParams,
+              typeExp
             )
         })))
   
@@ -272,61 +272,61 @@ object Codec{
         tag match {
           case """ExtensibleRecord""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
-              arg3 <- c.downN(3).as(morphir.sdk.list.Codec.decodeList(morphir.ir._type.Codec.decodeField(decodeA)))
+              attrs <- c.downN(1).as(decodeA)
+              variableName <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
+              fieldTypes <- c.downN(3).as(morphir.sdk.list.Codec.decodeList(morphir.ir._type.Codec.decodeField(decodeA)))
             }  yield morphir.ir.Type.ExtensibleRecord(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              variableName,
+              fieldTypes
             )
           case """Function""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.ir._type.Codec.decodeType(decodeA))
-              arg3 <- c.downN(3).as(morphir.ir._type.Codec.decodeType(decodeA))
+              attrs <- c.downN(1).as(decodeA)
+              argumentType <- c.downN(2).as(morphir.ir._type.Codec.decodeType(decodeA))
+              returnType <- c.downN(3).as(morphir.ir._type.Codec.decodeType(decodeA))
             }  yield morphir.ir.Type.Function(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              argumentType,
+              returnType
             )
           case """Record""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir._type.Codec.decodeField(decodeA)))
+              attrs <- c.downN(1).as(decodeA)
+              fieldTypes <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir._type.Codec.decodeField(decodeA)))
             }  yield morphir.ir.Type.Record(
-              arg1,
-              arg2
+              attrs,
+              fieldTypes
             )
           case """Reference""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.ir.fqname.Codec.decodeFQName)
-              arg3 <- c.downN(3).as(morphir.sdk.list.Codec.decodeList(morphir.ir._type.Codec.decodeType(decodeA)))
+              attrs <- c.downN(1).as(decodeA)
+              typeName <- c.downN(2).as(morphir.ir.fqname.Codec.decodeFQName)
+              typeParameters <- c.downN(3).as(morphir.sdk.list.Codec.decodeList(morphir.ir._type.Codec.decodeType(decodeA)))
             }  yield morphir.ir.Type.Reference(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              typeName,
+              typeParameters
             )
           case """Tuple""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir._type.Codec.decodeType(decodeA)))
+              attrs <- c.downN(1).as(decodeA)
+              elementTypes <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir._type.Codec.decodeType(decodeA)))
             }  yield morphir.ir.Type.Tuple(
-              arg1,
-              arg2
+              attrs,
+              elementTypes
             )
           case """Unit""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-            }  yield morphir.ir.Type.Unit(arg1)
+              attrs <- c.downN(1).as(decodeA)
+            }  yield morphir.ir.Type.Unit(attrs)
           case """Variable""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
+              attrs <- c.downN(1).as(decodeA)
+              name <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
             }  yield morphir.ir.Type.Variable(
-              arg1,
-              arg2
+              attrs,
+              name
             )
         })))
 

--- a/morphir/ir/src/morphir/ir/distribution/Codec.scala
+++ b/morphir/ir/src/morphir/ir/distribution/Codec.scala
@@ -4,22 +4,82 @@ package morphir.ir.distribution
 */
 object Codec{
 
+  implicit val encodeComponent: io.circe.Encoder[morphir.ir.Distribution.Component] = ((component: morphir.ir.Distribution.Component) =>
+    io.circe.Json.obj(
+      ("""name""", morphir.ir.path.Codec.encodePath(component.name)),
+      ("""libraries""", morphir.sdk.dict.Codec.encodeDict(
+        morphir.ir._package.Codec.encodePackageName,
+        morphir.ir._package.Codec.encodeDefinition(
+          morphir.sdk.basics.Codec.encodeUnit,
+          morphir.ir._type.Codec.encodeType(morphir.sdk.basics.Codec.encodeUnit)
+        )
+      )(component.libraries)),
+      ("""inputs""", morphir.sdk.dict.Codec.encodeDict(
+        morphir.ir.name.Codec.encodeName,
+        morphir.ir._type.Codec.encodeType(morphir.sdk.basics.Codec.encodeUnit)
+      )(component.inputs)),
+      ("""states""", morphir.sdk.dict.Codec.encodeDict(
+        morphir.ir.name.Codec.encodeName,
+        morphir.ir._type.Codec.encodeType(morphir.sdk.basics.Codec.encodeUnit)
+      )(component.states)),
+      ("""outputs""", morphir.sdk.dict.Codec.encodeDict(
+        morphir.ir.name.Codec.encodeName,
+        morphir.ir.value.Codec.encodeValue(
+          morphir.sdk.basics.Codec.encodeUnit,
+          morphir.ir._type.Codec.encodeType(morphir.sdk.basics.Codec.encodeUnit)
+        )
+      )(component.outputs))
+    ))
+  
   implicit val encodeDistribution: io.circe.Encoder[morphir.ir.Distribution.Distribution] = ((distribution: morphir.ir.Distribution.Distribution) =>
     distribution match {
-      case morphir.ir.Distribution.Library(arg1, arg2, arg3) => 
+      case morphir.ir.Distribution.Library(packageName, dependencies, packageDef) => 
         io.circe.Json.arr(
           io.circe.Json.fromString("""Library"""),
-          morphir.ir._package.Codec.encodePackageName(arg1),
+          morphir.ir._package.Codec.encodePackageName(packageName),
           morphir.sdk.dict.Codec.encodeDict(
             morphir.ir._package.Codec.encodePackageName,
             morphir.ir._package.Codec.encodeSpecification(morphir.sdk.basics.Codec.encodeUnit)
-          )(arg2),
+          )(dependencies),
           morphir.ir._package.Codec.encodeDefinition(
             morphir.sdk.basics.Codec.encodeUnit,
             morphir.ir._type.Codec.encodeType(morphir.sdk.basics.Codec.encodeUnit)
-          )(arg3)
+          )(packageDef)
         )
     })
+  
+  implicit val decodeComponent: io.circe.Decoder[morphir.ir.Distribution.Component] = ((c: io.circe.HCursor) =>
+    for {
+      name_ <- c.downField("""name""").as(morphir.ir.path.Codec.decodePath)
+      libraries_ <- c.downField("""libraries""").as(morphir.sdk.dict.Codec.decodeDict(
+        morphir.ir._package.Codec.decodePackageName,
+        morphir.ir._package.Codec.decodeDefinition(
+          morphir.sdk.basics.Codec.decodeUnit,
+          morphir.ir._type.Codec.decodeType(morphir.sdk.basics.Codec.decodeUnit)
+        )
+      ))
+      inputs_ <- c.downField("""inputs""").as(morphir.sdk.dict.Codec.decodeDict(
+        morphir.ir.name.Codec.decodeName,
+        morphir.ir._type.Codec.decodeType(morphir.sdk.basics.Codec.decodeUnit)
+      ))
+      states_ <- c.downField("""states""").as(morphir.sdk.dict.Codec.decodeDict(
+        morphir.ir.name.Codec.decodeName,
+        morphir.ir._type.Codec.decodeType(morphir.sdk.basics.Codec.decodeUnit)
+      ))
+      outputs_ <- c.downField("""outputs""").as(morphir.sdk.dict.Codec.decodeDict(
+        morphir.ir.name.Codec.decodeName,
+        morphir.ir.value.Codec.decodeValue(
+          morphir.sdk.basics.Codec.decodeUnit,
+          morphir.ir._type.Codec.decodeType(morphir.sdk.basics.Codec.decodeUnit)
+        )
+      ))
+    }  yield morphir.ir.Distribution.Component(
+      name_,
+      libraries_,
+      inputs_,
+      states_,
+      outputs_
+    ))
   
   implicit val decodeDistribution: io.circe.Decoder[morphir.ir.Distribution.Distribution] = ((c: io.circe.HCursor) =>
     c.withFocus(_.withString(((str) =>
@@ -27,19 +87,19 @@ object Codec{
       tag match {
         case """Library""" => 
           for {
-            arg1 <- c.downN(1).as(morphir.ir._package.Codec.decodePackageName)
-            arg2 <- c.downN(2).as(morphir.sdk.dict.Codec.decodeDict(
+            packageName <- c.downN(1).as(morphir.ir._package.Codec.decodePackageName)
+            dependencies <- c.downN(2).as(morphir.sdk.dict.Codec.decodeDict(
               morphir.ir._package.Codec.decodePackageName,
               morphir.ir._package.Codec.decodeSpecification(morphir.sdk.basics.Codec.decodeUnit)
             ))
-            arg3 <- c.downN(3).as(morphir.ir._package.Codec.decodeDefinition(
+            packageDef <- c.downN(3).as(morphir.ir._package.Codec.decodeDefinition(
               morphir.sdk.basics.Codec.decodeUnit,
               morphir.ir._type.Codec.decodeType(morphir.sdk.basics.Codec.decodeUnit)
             ))
           }  yield morphir.ir.Distribution.Library(
-            arg1,
-            arg2,
-            arg3
+            packageName,
+            dependencies,
+            packageDef
           )
       })))
 

--- a/morphir/ir/src/morphir/ir/literal/Codec.scala
+++ b/morphir/ir/src/morphir/ir/literal/Codec.scala
@@ -6,35 +6,35 @@ object Codec{
 
   implicit val encodeLiteral: io.circe.Encoder[morphir.ir.Literal.Literal] = ((literal: morphir.ir.Literal.Literal) =>
     literal match {
-      case morphir.ir.Literal.BoolLiteral(arg1) => 
+      case morphir.ir.Literal.BoolLiteral(value) => 
         io.circe.Json.arr(
           io.circe.Json.fromString("""BoolLiteral"""),
-          morphir.sdk.basics.Codec.encodeBool(arg1)
+          morphir.sdk.basics.Codec.encodeBool(value)
         )
-      case morphir.ir.Literal.CharLiteral(arg1) => 
+      case morphir.ir.Literal.CharLiteral(value) => 
         io.circe.Json.arr(
           io.circe.Json.fromString("""CharLiteral"""),
-          morphir.sdk.char.Codec.encodeChar(arg1)
+          morphir.sdk.char.Codec.encodeChar(value)
         )
-      case morphir.ir.Literal.DecimalLiteral(arg1) => 
+      case morphir.ir.Literal.DecimalLiteral(value) => 
         io.circe.Json.arr(
           io.circe.Json.fromString("""DecimalLiteral"""),
-          morphir.sdk.decimal.Codec.encodeDecimal(arg1)
+          morphir.sdk.decimal.Codec.encodeDecimal(value)
         )
-      case morphir.ir.Literal.FloatLiteral(arg1) => 
+      case morphir.ir.Literal.FloatLiteral(value) => 
         io.circe.Json.arr(
           io.circe.Json.fromString("""FloatLiteral"""),
-          morphir.sdk.basics.Codec.encodeFloat(arg1)
+          morphir.sdk.basics.Codec.encodeFloat(value)
         )
-      case morphir.ir.Literal.StringLiteral(arg1) => 
+      case morphir.ir.Literal.StringLiteral(value) => 
         io.circe.Json.arr(
           io.circe.Json.fromString("""StringLiteral"""),
-          morphir.sdk.string.Codec.encodeString(arg1)
+          morphir.sdk.string.Codec.encodeString(value)
         )
-      case morphir.ir.Literal.WholeNumberLiteral(arg1) => 
+      case morphir.ir.Literal.WholeNumberLiteral(value) => 
         io.circe.Json.arr(
           io.circe.Json.fromString("""WholeNumberLiteral"""),
-          morphir.sdk.basics.Codec.encodeInt(arg1)
+          morphir.sdk.basics.Codec.encodeInt(value)
         )
     })
   
@@ -44,28 +44,28 @@ object Codec{
       tag match {
         case """BoolLiteral""" => 
           for {
-            arg1 <- c.downN(1).as(morphir.sdk.basics.Codec.decodeBool)
-          }  yield morphir.ir.Literal.BoolLiteral(arg1)
+            value <- c.downN(1).as(morphir.sdk.basics.Codec.decodeBool)
+          }  yield morphir.ir.Literal.BoolLiteral(value)
         case """CharLiteral""" => 
           for {
-            arg1 <- c.downN(1).as(morphir.sdk.char.Codec.decodeChar)
-          }  yield morphir.ir.Literal.CharLiteral(arg1)
+            value <- c.downN(1).as(morphir.sdk.char.Codec.decodeChar)
+          }  yield morphir.ir.Literal.CharLiteral(value)
         case """DecimalLiteral""" => 
           for {
-            arg1 <- c.downN(1).as(morphir.sdk.decimal.Codec.decodeDecimal)
-          }  yield morphir.ir.Literal.DecimalLiteral(arg1)
+            value <- c.downN(1).as(morphir.sdk.decimal.Codec.decodeDecimal)
+          }  yield morphir.ir.Literal.DecimalLiteral(value)
         case """FloatLiteral""" => 
           for {
-            arg1 <- c.downN(1).as(morphir.sdk.basics.Codec.decodeFloat)
-          }  yield morphir.ir.Literal.FloatLiteral(arg1)
+            value <- c.downN(1).as(morphir.sdk.basics.Codec.decodeFloat)
+          }  yield morphir.ir.Literal.FloatLiteral(value)
         case """StringLiteral""" => 
           for {
-            arg1 <- c.downN(1).as(morphir.sdk.string.Codec.decodeString)
-          }  yield morphir.ir.Literal.StringLiteral(arg1)
+            value <- c.downN(1).as(morphir.sdk.string.Codec.decodeString)
+          }  yield morphir.ir.Literal.StringLiteral(value)
         case """WholeNumberLiteral""" => 
           for {
-            arg1 <- c.downN(1).as(morphir.sdk.basics.Codec.decodeInt)
-          }  yield morphir.ir.Literal.WholeNumberLiteral(arg1)
+            value <- c.downN(1).as(morphir.sdk.basics.Codec.decodeInt)
+          }  yield morphir.ir.Literal.WholeNumberLiteral(value)
       })))
 
 }

--- a/morphir/ir/src/morphir/ir/value/Codec.scala
+++ b/morphir/ir/src/morphir/ir/value/Codec.scala
@@ -28,53 +28,53 @@ object Codec{
   ): io.circe.Encoder[morphir.ir.Value.Pattern[A]] =
     ((pattern: morphir.ir.Value.Pattern[A]) =>
       pattern match {
-        case morphir.ir.Value.AsPattern(arg1, arg2, arg3) => 
+        case morphir.ir.Value.AsPattern(attrs, pattern, name) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""AsPattern"""),
-            encodeA(arg1),
-            morphir.ir.value.Codec.encodePattern(encodeA)(arg2),
-            morphir.ir.name.Codec.encodeName(arg3)
+            encodeA(attrs),
+            morphir.ir.value.Codec.encodePattern(encodeA)(pattern),
+            morphir.ir.name.Codec.encodeName(name)
           )
-        case morphir.ir.Value.ConstructorPattern(arg1, arg2, arg3) => 
+        case morphir.ir.Value.ConstructorPattern(attrs, constructorName, argumentPatterns) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""ConstructorPattern"""),
-            encodeA(arg1),
-            morphir.ir.fqname.Codec.encodeFQName(arg2),
-            morphir.sdk.list.Codec.encodeList(morphir.ir.value.Codec.encodePattern(encodeA))(arg3)
+            encodeA(attrs),
+            morphir.ir.fqname.Codec.encodeFQName(constructorName),
+            morphir.sdk.list.Codec.encodeList(morphir.ir.value.Codec.encodePattern(encodeA))(argumentPatterns)
           )
-        case morphir.ir.Value.EmptyListPattern(arg1) => 
+        case morphir.ir.Value.EmptyListPattern(attrs) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""EmptyListPattern"""),
-            encodeA(arg1)
+            encodeA(attrs)
           )
-        case morphir.ir.Value.HeadTailPattern(arg1, arg2, arg3) => 
+        case morphir.ir.Value.HeadTailPattern(attrs, headPattern, tailPattern) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""HeadTailPattern"""),
-            encodeA(arg1),
-            morphir.ir.value.Codec.encodePattern(encodeA)(arg2),
-            morphir.ir.value.Codec.encodePattern(encodeA)(arg3)
+            encodeA(attrs),
+            morphir.ir.value.Codec.encodePattern(encodeA)(headPattern),
+            morphir.ir.value.Codec.encodePattern(encodeA)(tailPattern)
           )
-        case morphir.ir.Value.LiteralPattern(arg1, arg2) => 
+        case morphir.ir.Value.LiteralPattern(attrs, value) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""LiteralPattern"""),
-            encodeA(arg1),
-            morphir.ir.literal.Codec.encodeLiteral(arg2)
+            encodeA(attrs),
+            morphir.ir.literal.Codec.encodeLiteral(value)
           )
-        case morphir.ir.Value.TuplePattern(arg1, arg2) => 
+        case morphir.ir.Value.TuplePattern(attrs, elementPatterns) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""TuplePattern"""),
-            encodeA(arg1),
-            morphir.sdk.list.Codec.encodeList(morphir.ir.value.Codec.encodePattern(encodeA))(arg2)
+            encodeA(attrs),
+            morphir.sdk.list.Codec.encodeList(morphir.ir.value.Codec.encodePattern(encodeA))(elementPatterns)
           )
-        case morphir.ir.Value.UnitPattern(arg1) => 
+        case morphir.ir.Value.UnitPattern(attrs) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""UnitPattern"""),
-            encodeA(arg1)
+            encodeA(attrs)
           )
-        case morphir.ir.Value.WildcardPattern(arg1) => 
+        case morphir.ir.Value.WildcardPattern(attrs) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""WildcardPattern"""),
-            encodeA(arg1)
+            encodeA(attrs)
           )
       })
   
@@ -107,197 +107,197 @@ object Codec{
   ): io.circe.Encoder[morphir.ir.Value.Value[Ta, Va]] =
     ((value: morphir.ir.Value.Value[Ta, Va]) =>
       value match {
-        case morphir.ir.Value.Apply(arg1, arg2, arg3) => 
+        case morphir.ir.Value.Apply(attrs, func, argument) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Apply"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg2),
+            )(func),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg3)
+            )(argument)
           )
-        case morphir.ir.Value.Constructor(arg1, arg2) => 
+        case morphir.ir.Value.Constructor(attrs, fullyQualifiedName) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Constructor"""),
-            encodeVa(arg1),
-            morphir.ir.fqname.Codec.encodeFQName(arg2)
+            encodeVa(attrs),
+            morphir.ir.fqname.Codec.encodeFQName(fullyQualifiedName)
           )
-        case morphir.ir.Value.Destructure(arg1, arg2, arg3, arg4) => 
+        case morphir.ir.Value.Destructure(attrs, pattern, valueToDestruct, inValue) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Destructure"""),
-            encodeVa(arg1),
-            morphir.ir.value.Codec.encodePattern(encodeVa)(arg2),
+            encodeVa(attrs),
+            morphir.ir.value.Codec.encodePattern(encodeVa)(pattern),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg3),
+            )(valueToDestruct),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg4)
+            )(inValue)
           )
-        case morphir.ir.Value.Field(arg1, arg2, arg3) => 
+        case morphir.ir.Value.Field(attrs, subjectValue, fieldName) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Field"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg2),
-            morphir.ir.name.Codec.encodeName(arg3)
+            )(subjectValue),
+            morphir.ir.name.Codec.encodeName(fieldName)
           )
-        case morphir.ir.Value.FieldFunction(arg1, arg2) => 
+        case morphir.ir.Value.FieldFunction(attrs, fieldName) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""FieldFunction"""),
-            encodeVa(arg1),
-            morphir.ir.name.Codec.encodeName(arg2)
+            encodeVa(attrs),
+            morphir.ir.name.Codec.encodeName(fieldName)
           )
-        case morphir.ir.Value.IfThenElse(arg1, arg2, arg3, arg4) => 
+        case morphir.ir.Value.IfThenElse(attrs, condition, thenBranch, elseBranch) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""IfThenElse"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg2),
+            )(condition),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg3),
+            )(thenBranch),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg4)
+            )(elseBranch)
           )
-        case morphir.ir.Value.Lambda(arg1, arg2, arg3) => 
+        case morphir.ir.Value.Lambda(attrs, argumentPattern, body) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Lambda"""),
-            encodeVa(arg1),
-            morphir.ir.value.Codec.encodePattern(encodeVa)(arg2),
+            encodeVa(attrs),
+            morphir.ir.value.Codec.encodePattern(encodeVa)(argumentPattern),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg3)
+            )(body)
           )
-        case morphir.ir.Value.LetDefinition(arg1, arg2, arg3, arg4) => 
+        case morphir.ir.Value.LetDefinition(attrs, valueName, valueDefinition, inValue) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""LetDefinition"""),
-            encodeVa(arg1),
-            morphir.ir.name.Codec.encodeName(arg2),
+            encodeVa(attrs),
+            morphir.ir.name.Codec.encodeName(valueName),
             morphir.ir.value.Codec.encodeDefinition(
               encodeTa,
               encodeVa
-            )(arg3),
+            )(valueDefinition),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg4)
+            )(inValue)
           )
-        case morphir.ir.Value.LetRecursion(arg1, arg2, arg3) => 
+        case morphir.ir.Value.LetRecursion(attrs, valueDefinitions, inValue) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""LetRecursion"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.sdk.dict.Codec.encodeDict(
               morphir.ir.name.Codec.encodeName,
               morphir.ir.value.Codec.encodeDefinition(
                 encodeTa,
                 encodeVa
               )
-            )(arg2),
+            )(valueDefinitions),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg3)
+            )(inValue)
           )
-        case morphir.ir.Value.List(arg1, arg2) => 
+        case morphir.ir.Value.List(attrs, items) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""List"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.sdk.list.Codec.encodeList(morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            ))(arg2)
+            ))(items)
           )
-        case morphir.ir.Value.Literal(arg1, arg2) => 
+        case morphir.ir.Value.Literal(attrs, value) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Literal"""),
-            encodeVa(arg1),
-            morphir.ir.literal.Codec.encodeLiteral(arg2)
+            encodeVa(attrs),
+            morphir.ir.literal.Codec.encodeLiteral(value)
           )
-        case morphir.ir.Value.PatternMatch(arg1, arg2, arg3) => 
+        case morphir.ir.Value.PatternMatch(attrs, branchOutOn, cases) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""PatternMatch"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg2),
-            morphir.sdk.list.Codec.encodeList(((arg3: (morphir.ir.Value.Pattern[Va], morphir.ir.Value.Value[Ta, Va])) =>
+            )(branchOutOn),
+            morphir.sdk.list.Codec.encodeList(((cases: (morphir.ir.Value.Pattern[Va], morphir.ir.Value.Value[Ta, Va])) =>
               io.circe.Json.arr(
-                morphir.ir.value.Codec.encodePattern(encodeVa)(arg3._1),
+                morphir.ir.value.Codec.encodePattern(encodeVa)(cases._1),
                 morphir.ir.value.Codec.encodeValue(
                   encodeTa,
                   encodeVa
-                )(arg3._2)
-              )))(arg3)
+                )(cases._2)
+              )))(cases)
           )
-        case morphir.ir.Value.Record(arg1, arg2) => 
+        case morphir.ir.Value.Record(attrs, fields) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Record"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.sdk.dict.Codec.encodeDict(
               morphir.ir.name.Codec.encodeName,
               morphir.ir.value.Codec.encodeValue(
                 encodeTa,
                 encodeVa
               )
-            )(arg2)
+            )(fields)
           )
-        case morphir.ir.Value.Reference(arg1, arg2) => 
+        case morphir.ir.Value.Reference(attrs, fullyQualifiedName) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Reference"""),
-            encodeVa(arg1),
-            morphir.ir.fqname.Codec.encodeFQName(arg2)
+            encodeVa(attrs),
+            morphir.ir.fqname.Codec.encodeFQName(fullyQualifiedName)
           )
-        case morphir.ir.Value.Tuple(arg1, arg2) => 
+        case morphir.ir.Value.Tuple(attrs, elements) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Tuple"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.sdk.list.Codec.encodeList(morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            ))(arg2)
+            ))(elements)
           )
-        case morphir.ir.Value.Unit(arg1) => 
+        case morphir.ir.Value.Unit(attrs) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Unit"""),
-            encodeVa(arg1)
+            encodeVa(attrs)
           )
-        case morphir.ir.Value.UpdateRecord(arg1, arg2, arg3) => 
+        case morphir.ir.Value.UpdateRecord(attrs, valueToUpdate, fieldsToUpdate) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""UpdateRecord"""),
-            encodeVa(arg1),
+            encodeVa(attrs),
             morphir.ir.value.Codec.encodeValue(
               encodeTa,
               encodeVa
-            )(arg2),
+            )(valueToUpdate),
             morphir.sdk.dict.Codec.encodeDict(
               morphir.ir.name.Codec.encodeName,
               morphir.ir.value.Codec.encodeValue(
                 encodeTa,
                 encodeVa
               )
-            )(arg3)
+            )(fieldsToUpdate)
           )
-        case morphir.ir.Value.Variable(arg1, arg2) => 
+        case morphir.ir.Value.Variable(attrs, name) => 
           io.circe.Json.arr(
             io.circe.Json.fromString("""Variable"""),
-            encodeVa(arg1),
-            morphir.ir.name.Codec.encodeName(arg2)
+            encodeVa(attrs),
+            morphir.ir.name.Codec.encodeName(name)
           )
       })
   
@@ -333,62 +333,62 @@ object Codec{
         tag match {
           case """AsPattern""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodePattern(decodeA))
-              arg3 <- c.downN(3).as(morphir.ir.name.Codec.decodeName)
+              attrs <- c.downN(1).as(decodeA)
+              pattern <- c.downN(2).as(morphir.ir.value.Codec.decodePattern(decodeA))
+              name <- c.downN(3).as(morphir.ir.name.Codec.decodeName)
             }  yield morphir.ir.Value.AsPattern(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              pattern,
+              name
             )
           case """ConstructorPattern""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.ir.fqname.Codec.decodeFQName)
-              arg3 <- c.downN(3).as(morphir.sdk.list.Codec.decodeList(morphir.ir.value.Codec.decodePattern(decodeA)))
+              attrs <- c.downN(1).as(decodeA)
+              constructorName <- c.downN(2).as(morphir.ir.fqname.Codec.decodeFQName)
+              argumentPatterns <- c.downN(3).as(morphir.sdk.list.Codec.decodeList(morphir.ir.value.Codec.decodePattern(decodeA)))
             }  yield morphir.ir.Value.ConstructorPattern(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              constructorName,
+              argumentPatterns
             )
           case """EmptyListPattern""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-            }  yield morphir.ir.Value.EmptyListPattern(arg1)
+              attrs <- c.downN(1).as(decodeA)
+            }  yield morphir.ir.Value.EmptyListPattern(attrs)
           case """HeadTailPattern""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodePattern(decodeA))
-              arg3 <- c.downN(3).as(morphir.ir.value.Codec.decodePattern(decodeA))
+              attrs <- c.downN(1).as(decodeA)
+              headPattern <- c.downN(2).as(morphir.ir.value.Codec.decodePattern(decodeA))
+              tailPattern <- c.downN(3).as(morphir.ir.value.Codec.decodePattern(decodeA))
             }  yield morphir.ir.Value.HeadTailPattern(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              headPattern,
+              tailPattern
             )
           case """LiteralPattern""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.ir.literal.Codec.decodeLiteral)
+              attrs <- c.downN(1).as(decodeA)
+              value <- c.downN(2).as(morphir.ir.literal.Codec.decodeLiteral)
             }  yield morphir.ir.Value.LiteralPattern(
-              arg1,
-              arg2
+              attrs,
+              value
             )
           case """TuplePattern""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-              arg2 <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir.value.Codec.decodePattern(decodeA)))
+              attrs <- c.downN(1).as(decodeA)
+              elementPatterns <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir.value.Codec.decodePattern(decodeA)))
             }  yield morphir.ir.Value.TuplePattern(
-              arg1,
-              arg2
+              attrs,
+              elementPatterns
             )
           case """UnitPattern""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-            }  yield morphir.ir.Value.UnitPattern(arg1)
+              attrs <- c.downN(1).as(decodeA)
+            }  yield morphir.ir.Value.UnitPattern(attrs)
           case """WildcardPattern""" => 
             for {
-              arg1 <- c.downN(1).as(decodeA)
-            }  yield morphir.ir.Value.WildcardPattern(arg1)
+              attrs <- c.downN(1).as(decodeA)
+            }  yield morphir.ir.Value.WildcardPattern(attrs)
         })))
   
   implicit val decodeRawValue: io.circe.Decoder[morphir.ir.Value.RawValue] = morphir.ir.value.Codec.decodeValue(
@@ -427,165 +427,165 @@ object Codec{
         tag match {
           case """Apply""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              func <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
-              arg3 <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
+              argument <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
             }  yield morphir.ir.Value.Apply(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              func,
+              argument
             )
           case """Constructor""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.fqname.Codec.decodeFQName)
+              attrs <- c.downN(1).as(decodeVa)
+              fullyQualifiedName <- c.downN(2).as(morphir.ir.fqname.Codec.decodeFQName)
             }  yield morphir.ir.Value.Constructor(
-              arg1,
-              arg2
+              attrs,
+              fullyQualifiedName
             )
           case """Destructure""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodePattern(decodeVa))
-              arg3 <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              pattern <- c.downN(2).as(morphir.ir.value.Codec.decodePattern(decodeVa))
+              valueToDestruct <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
-              arg4 <- c.downN(4).as(morphir.ir.value.Codec.decodeValue(
+              inValue <- c.downN(4).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
             }  yield morphir.ir.Value.Destructure(
-              arg1,
-              arg2,
-              arg3,
-              arg4
+              attrs,
+              pattern,
+              valueToDestruct,
+              inValue
             )
           case """Field""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              subjectValue <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
-              arg3 <- c.downN(3).as(morphir.ir.name.Codec.decodeName)
+              fieldName <- c.downN(3).as(morphir.ir.name.Codec.decodeName)
             }  yield morphir.ir.Value.Field(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              subjectValue,
+              fieldName
             )
           case """FieldFunction""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
+              attrs <- c.downN(1).as(decodeVa)
+              fieldName <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
             }  yield morphir.ir.Value.FieldFunction(
-              arg1,
-              arg2
+              attrs,
+              fieldName
             )
           case """IfThenElse""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              condition <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
-              arg3 <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
+              thenBranch <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
-              arg4 <- c.downN(4).as(morphir.ir.value.Codec.decodeValue(
+              elseBranch <- c.downN(4).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
             }  yield morphir.ir.Value.IfThenElse(
-              arg1,
-              arg2,
-              arg3,
-              arg4
+              attrs,
+              condition,
+              thenBranch,
+              elseBranch
             )
           case """Lambda""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodePattern(decodeVa))
-              arg3 <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              argumentPattern <- c.downN(2).as(morphir.ir.value.Codec.decodePattern(decodeVa))
+              body <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
             }  yield morphir.ir.Value.Lambda(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              argumentPattern,
+              body
             )
           case """LetDefinition""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
-              arg3 <- c.downN(3).as(morphir.ir.value.Codec.decodeDefinition(
+              attrs <- c.downN(1).as(decodeVa)
+              valueName <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
+              valueDefinition <- c.downN(3).as(morphir.ir.value.Codec.decodeDefinition(
                 decodeTa,
                 decodeVa
               ))
-              arg4 <- c.downN(4).as(morphir.ir.value.Codec.decodeValue(
+              inValue <- c.downN(4).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
             }  yield morphir.ir.Value.LetDefinition(
-              arg1,
-              arg2,
-              arg3,
-              arg4
+              attrs,
+              valueName,
+              valueDefinition,
+              inValue
             )
           case """LetRecursion""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.sdk.dict.Codec.decodeDict(
+              attrs <- c.downN(1).as(decodeVa)
+              valueDefinitions <- c.downN(2).as(morphir.sdk.dict.Codec.decodeDict(
                 morphir.ir.name.Codec.decodeName,
                 morphir.ir.value.Codec.decodeDefinition(
                   decodeTa,
                   decodeVa
                 )
               ))
-              arg3 <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
+              inValue <- c.downN(3).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
             }  yield morphir.ir.Value.LetRecursion(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              valueDefinitions,
+              inValue
             )
           case """List""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              items <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               )))
             }  yield morphir.ir.Value.List(
-              arg1,
-              arg2
+              attrs,
+              items
             )
           case """Literal""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.literal.Codec.decodeLiteral)
+              attrs <- c.downN(1).as(decodeVa)
+              value <- c.downN(2).as(morphir.ir.literal.Codec.decodeLiteral)
             }  yield morphir.ir.Value.Literal(
-              arg1,
-              arg2
+              attrs,
+              value
             )
           case """PatternMatch""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              branchOutOn <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
-              arg3 <- c.downN(3).as(morphir.sdk.list.Codec.decodeList(((c: io.circe.HCursor) =>
+              cases <- c.downN(3).as(morphir.sdk.list.Codec.decodeList(((c: io.circe.HCursor) =>
                 for {
                   arg1 <- c.downN(0).as(morphir.ir.value.Codec.decodePattern(decodeVa))
                   arg2 <- c.downN(1).as(morphir.ir.value.Codec.decodeValue(
@@ -594,14 +594,14 @@ object Codec{
                   ))
                 }  yield (arg1, arg2))))
             }  yield morphir.ir.Value.PatternMatch(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              branchOutOn,
+              cases
             )
           case """Record""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.sdk.dict.Codec.decodeDict(
+              attrs <- c.downN(1).as(decodeVa)
+              fields <- c.downN(2).as(morphir.sdk.dict.Codec.decodeDict(
                 morphir.ir.name.Codec.decodeName,
                 morphir.ir.value.Codec.decodeValue(
                   decodeTa,
@@ -609,40 +609,40 @@ object Codec{
                 )
               ))
             }  yield morphir.ir.Value.Record(
-              arg1,
-              arg2
+              attrs,
+              fields
             )
           case """Reference""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.fqname.Codec.decodeFQName)
+              attrs <- c.downN(1).as(decodeVa)
+              fullyQualifiedName <- c.downN(2).as(morphir.ir.fqname.Codec.decodeFQName)
             }  yield morphir.ir.Value.Reference(
-              arg1,
-              arg2
+              attrs,
+              fullyQualifiedName
             )
           case """Tuple""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              elements <- c.downN(2).as(morphir.sdk.list.Codec.decodeList(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               )))
             }  yield morphir.ir.Value.Tuple(
-              arg1,
-              arg2
+              attrs,
+              elements
             )
           case """Unit""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-            }  yield morphir.ir.Value.Unit(arg1)
+              attrs <- c.downN(1).as(decodeVa)
+            }  yield morphir.ir.Value.Unit(attrs)
           case """UpdateRecord""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
+              attrs <- c.downN(1).as(decodeVa)
+              valueToUpdate <- c.downN(2).as(morphir.ir.value.Codec.decodeValue(
                 decodeTa,
                 decodeVa
               ))
-              arg3 <- c.downN(3).as(morphir.sdk.dict.Codec.decodeDict(
+              fieldsToUpdate <- c.downN(3).as(morphir.sdk.dict.Codec.decodeDict(
                 morphir.ir.name.Codec.decodeName,
                 morphir.ir.value.Codec.decodeValue(
                   decodeTa,
@@ -650,17 +650,17 @@ object Codec{
                 )
               ))
             }  yield morphir.ir.Value.UpdateRecord(
-              arg1,
-              arg2,
-              arg3
+              attrs,
+              valueToUpdate,
+              fieldsToUpdate
             )
           case """Variable""" => 
             for {
-              arg1 <- c.downN(1).as(decodeVa)
-              arg2 <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
+              attrs <- c.downN(1).as(decodeVa)
+              name <- c.downN(2).as(morphir.ir.name.Codec.decodeName)
             }  yield morphir.ir.Value.Variable(
-              arg1,
-              arg2
+              attrs,
+              name
             )
         })))
 


### PR DESCRIPTION
# This is the 1st commit message:

Update Scala 3 to Scala 3.3.5 and properly upgrade Scala Native (#197)

# This is the commit message #2:

Added component IR types + better variable names

# This is the commit message #3:

Added component IR types + better variable names